### PR TITLE
Fix controller button messages not being sent

### DIFF
--- a/SignallingWebServer/scripts/app.js
+++ b/SignallingWebServer/scripts/app.js
@@ -168,6 +168,7 @@ function emitControllerButtonPressed(controllerIndex, buttonIndex, isRepeat) {
     Data.setUint8(1, controllerIndex);
     Data.setUint8(2, buttonIndex);
     Data.setUint8(3, isRepeat);
+    sendInputData(Data.buffer);
 }
 
 function emitControllerButtonReleased(controllerIndex, buttonIndex) {
@@ -175,6 +176,7 @@ function emitControllerButtonReleased(controllerIndex, buttonIndex) {
     Data.setUint8(0, MessageType.GamepadButtonReleased);
     Data.setUint8(1, controllerIndex);
     Data.setUint8(2, buttonIndex);
+    sendInputData(Data.buffer);
 }
 
 function emitControllerAxisMove(controllerIndex, axisIndex, analogValue) {


### PR DESCRIPTION
At the moment pressing and releasing gamepad buttons doesn't send any data back to UE. With this fix the messages are sent.

However, the triggers on an Xbox gamepad don't seem to work still. The messages send (and I can log them out in UE) but they don't have the same result as connecting a gamepad to UE locally.