### PR TITLE
Update cirrus logging to refer to UE version 4.27

### DIFF
--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -268,7 +268,7 @@ if (config.UseHTTPS) {
 	});
 }
 
-console.logColor(logging.Cyan, `Running Cirrus - The Pixel Streaming reference implementation signalling server for Unreal Engine 5.0.`);
+console.logColor(logging.Cyan, `Running Cirrus - The Pixel Streaming reference implementation signalling server for Unreal Engine 4.27.`);
 
 let nextPlayerId = 100; // reserve some player ids
 const SFUPlayerId = "1"; // sfu is a special kind of player


### PR DESCRIPTION
When the signalling server logs what version of UE it is for it now correctly says 4.27