### PR TITLE
Replaced hardcoded log path with given parameter path

### DIFF
--- a/SignallingWebServer/modules/logging.js
+++ b/SignallingWebServer/modules/logging.js
@@ -60,12 +60,12 @@ function timeToString() {
 
 function RegisterFileLogger(path) {
 	if(path == null)
-		path = './';
+		path = './logs/';
 	
 	if (!fs.existsSync(path))
 		fs.mkdirSync(path);
 	
-	var output = fs.createWriteStream(`./logs/${dateTimeToString()}.log`);
+	var output = fs.createWriteStream(`${path}${dateTimeToString()}.log`);
 	var fileLogger = new Console(output);
 	logFunctions.push(function(msg, ...args) {
 		fileLogger.log(`${timeToString()} ${msg}`, ...args);


### PR DESCRIPTION
Specifying a path with registering the file logger only created the folder, but never used it in creating the write stream.
Fixed it so that the parameter gets used in creating the write stream.