### PR TITLE
Indicate to the signalling server when the browser intends to send the offer

### DIFF
--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -978,6 +978,11 @@ export class WebRtcPlayerController {
             signallingServerUrl += '?' + Flags.PreferSFU + '=true';
         }
 
+		// If we are sending the offer add a special url parameter to the url, making sure we append correctly
+		if (this.config.isFlagEnabled(Flags.BrowserSendOffer)) {
+            signallingServerUrl += (signallingServerUrl.includes('?') ? '&' : '?') + Flags.BrowserSendOffer + '=true';
+        }
+
         return signallingServerUrl;
     }
 

--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -521,6 +521,7 @@ playerServer.on('connection', function (ws, req) {
 	const parsedUrl = url.parse(req.url);
 	const urlParams = new URLSearchParams(parsedUrl.search);
 	const preferSFU = urlParams.has('preferSFU') && urlParams.get('preferSFU') !== 'false';
+	const browserSendOffer = urlParams.has('OfferToReceive') && urlParams.get('OfferToReceive') !== 'false';
 	const skipSFU = !preferSFU;
 	const skipStreamer = preferSFU && sfu;
 
@@ -628,7 +629,7 @@ playerServer.on('connection', function (ws, req) {
 
 	ws.send(JSON.stringify(clientConfig));
 
-	sendMessageToController({ type: "playerConnected", playerId: playerId, dataChannel: true, sfu: false }, skipSFU, skipStreamer);
+	sendMessageToController({ type: "playerConnected", playerId: playerId, dataChannel: true, sfu: false, sendOffer: !browserSendOffer }, skipSFU, skipStreamer);
 	sendPlayersCount();
 });
 


### PR DESCRIPTION
This is useful when using UE5 as by default if the application receives a connection it will send an offer. In the case where the browser intends to send the offer we will connect but tell UE not to send the offer and instead wait to receive it.