### PR TITLE
Fix: Preferred codec selector causes no stream if application launched without `-PixelStreamingNegotiateCodecs`

### DIFF
--- a/Frontend/implementations/EpicGames/package-lock.json
+++ b/Frontend/implementations/EpicGames/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@epicgames/reference-pixelstreamingfrontend",
+  "name": "@epicgames-ps/reference-pixelstreamingfrontend",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@epicgames/reference-pixelstreamingfrontend",
+      "name": "@epicgames-ps/reference-pixelstreamingfrontend",
       "version": "0.0.1",
       "hasInstallScript": true,
       "devDependencies": {

--- a/Frontend/library/package-lock.json
+++ b/Frontend/library/package-lock.json
@@ -1,12 +1,13 @@
 {
-    "name": "@epicgames/lib-pixelstreamingfrontend-dev",
+    "name": "@epicgames-ps/lib-pixelstreamingfrontend-dev",
     "version": "0.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "@epicgames/lib-pixelstreamingfrontend-dev",
+            "name": "@epicgames-ps/lib-pixelstreamingfrontend-dev",
             "version": "0.0.1",
+            "license": "MIT",
             "dependencies": {
                 "jss": "^10.9.2",
                 "jss-plugin-camel-case": "^10.9.2",

--- a/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
+++ b/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
@@ -343,11 +343,27 @@ export class PeerConnectionController {
 						sdpFmtpLine: preferredRTPCodec[1] /* sdpFmtpLine */ ? preferredRTPCodec[1] : '' 
 					}];
 
-					if(codecs[0].sdpFmtpLine === '') {
-						// We can't dynamically add members to the codec, so instead remove the field if it's empty
-						delete codecs[0].sdpFmtpLine;
-					}
+					this.config.getSettingOption(OptionParameters.PreferredCodec).options
+					.filter((option) => {
+						// Remove the preferred codec from the list of possible codecs as we've set it already
+						return option != this.preferredCodec;
+					}).forEach((option) => {
+						// Ammend the rest of the browsers supported codecs
+						const altCodec = option.split(" ");
+						codecs.push({
+							mimeType: 'video/' + altCodec[0] /* Name */,
+							clockRate: 90000,
+							sdpFmtpLine: altCodec[1] /* sdpFmtpLine */ ? altCodec[1] : '' 
+						})
+					})
 
+					for(const codec of codecs) {
+						if(codec.sdpFmtpLine === '') {
+							// We can't dynamically add members to the codec, so instead remove the field if it's empty
+							delete codec.sdpFmtpLine;
+						}
+					}
+					
 					transceiver.setCodecPreferences(codecs);
 				}
 			}


### PR DESCRIPTION
This was due to the codec preference array only containing a single (the preferred) codec. 

Now, we set the preferred codec to be the first in the array with the remaining browser supported codecs coming after.