### PR TITLE
Gracefully handle unsupported message types

### DIFF
--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -385,7 +385,6 @@ streamerServer.on('connection', function (ws, req) {
 				}
 			} else {
 				console.error(`unsupported Streamer message type: ${msg.type}`);
-				streamer.close(1008, 'Unsupported message type');
 			}
 		} catch(err) {
 			console.error(`ERROR: ws.on message error: ${err.message}`);
@@ -587,7 +586,6 @@ playerServer.on('connection', function (ws, req) {
 		}
 		else {
 			console.error(`player ${playerId}: unsupported message type: ${msg.type}`);
-			ws.close(1008, 'Unsupported message type');
 			return;
 		}
 	});


### PR DESCRIPTION
Fixed by not force closing the websocket