### PR TITLE
Expose webRtcController from the PixelStreaming class

### DIFF
--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -601,4 +601,11 @@ export class PixelStreaming {
     public get webXrController() {
         return this._webXrController;
     }
+
+    /**
+     * Public getter for the webRtcController controller. Used for all WebRTC interactions.
+     */
+    public get webRtcController() {
+        return this._webRtcController;
+    }
 }


### PR DESCRIPTION
Exposing this member allows the [SPS Frontend](https://github.com/ScalablePixelStreaming/Frontend/) to override the construction of the Signalling Server URL