### PR TITLE
Use mediasoup's internal stream ids for SCTP to avoid clashes

### DIFF
--- a/SFU/sfu_server.js
+++ b/SFU/sfu_server.js
@@ -44,30 +44,7 @@ async function onStreamerOffer(sdp) {
 }
 
 function getNextStreamerSCTPId() {
-  if(!streamer){
-    throw new TypeError('Cannot generate an SCTP stream id - streamer was null.');
-  }
-  if (!streamer.transport || !streamer.transport.sctpParameters || typeof streamer.transport.sctpParameters.MIS !== 'number') {
-    throw new TypeError('Streamer was not setup with the following require properties: streamer.transport.sctpParameters.MIS');
-  }
-  const numStreams = streamer.transport.sctpParameters.MIS;
-  if (!streamer.dataStreamIds){
-    streamer.dataStreamIds = Buffer.alloc(numStreams, 0);
-  }
-  if (!streamer.nextDataStreamId) {
-    streamer.nextDataStreamId = 0;
-  }
-
-  let sctpStreamId;
-  for (let idx = streamer.nextDataStreamId; idx < streamer.dataStreamIds.length; ++idx) {
-      sctpStreamId = idx % streamer.dataStreamIds.length;
-      if (!streamer.dataStreamIds[sctpStreamId]) {
-          streamer.nextDataStreamId = sctpStreamId + 1;
-          return sctpStreamId;
-      }
-  }
-  console.error("No available SCTP ids, they are all allocated.");
-  return -1;
+	return streamer.transport._getNextSctpStreamId();
 }
 
 function onStreamerDisconnected() {
@@ -156,6 +133,9 @@ async function setupPeerDataChannels(peerId) {
   // streamer data consumer (consumes peer data)
   peer.streamerDataConsumer = await streamer.transport.consumeData({ dataProducerId: peer.peerDataProducer.id });
 
+  streamer.transport._sctpStreamIds[nextStreamerSCTPStreamId] = 1;
+  streamer.transport._sctpStreamIds[nextPeerSCTPStreamId] = 1;
+
   const peerSignal = {
     type: 'peerDataChannels',
     playerId: peerId,
@@ -217,11 +197,11 @@ function onPeerDisconnected(peerId) {
     }
     if(peer.streamerDataConsumer){
       // Set the streamer sctp id we generated back to zero indicating it can be reused.
-      if(streamer && streamer.dataStreamIds){
+      if(streamer && streamer.transport && streamer.transport._sctpStreamIds){
         const allocatedStreamId = peer.streamerDataProducer.sctpStreamParameters.streamId;
         const allocatedPeerStreamId = peer.peerDataProducer.sctpStreamParameters.streamId;
-        streamer.dataStreamIds[allocatedStreamId] = 0;
-        streamer.dataStreamIds[allocatedPeerStreamId] = 0;
+        streamer.transport._sctpStreamIds[allocatedStreamId] = 0;
+        streamer.transport._sctpStreamIds[allocatedPeerStreamId] = 0;
       }
       peer.streamerDataConsumer.close();
       peer.streamerDataProducer.close();


### PR DESCRIPTION
This should allow more than 2 peers to connect to the SFU without having Unreal Engine crash from stream channels being double-assigned.

Fixes #62 