### PR TITLE
Api support for UE communication

### DIFF
--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -566,7 +566,7 @@ export class PixelStreaming {
 
     /**
      * Send data to UE application. The data will be run through JSON.stringify() so e.g. strings
-     * and any serializable objects with no recurrence can be sent.
+     * and any serializable plain JSON objects with no recurrence can be sent.
      * @returns
      */
     public sendUIInteraction(descriptor: object) {

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -579,15 +579,18 @@ export class PixelStreaming {
     }
 
     /**
-     * Send a console command to UE application. Only allowed if UE has signaled that it allows
-     * console commands.
+     * Send a command to UE application. Blocks ConsoleCommand descriptors unless UE
+     * has signaled that it allows console commands.
      * @returns true if succeeded, false if rejected
      */
-    public emitConsoleCommand(command: string) {
-        if (!this.allowConsoleCommands || !this._webRtcController.videoPlayer.isVideoReady()) {
+    public emitCommand(descriptor: object) {
+        if (!this._webRtcController.videoPlayer.isVideoReady()) {
             return false;
         }
-        this._webRtcController.emitConsoleCommand(command);
+        if (!this.allowConsoleCommands && 'ConsoleCommand' in descriptor) {
+            return false;
+        }
+        this._webRtcController.emitCommand(descriptor);
         return true;
     }
 

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -565,6 +565,19 @@ export class PixelStreaming {
     }
 
     /**
+     * Send data to UE application. The data will be run through JSON.stringify() so e.g. strings
+     * and any serializable objects with no recurrence can be sent.
+     * @returns
+     */
+    public sendUIInteraction(descriptor: object) {
+        if (!this._webRtcController.videoPlayer.isVideoReady()) {
+            return false;
+        }
+        this._webRtcController.sendUIInteraction(descriptor);
+        return true;
+    }
+
+	/**
      * Dispatch a new event.
      * @param e event
      * @returns

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -583,11 +583,11 @@ export class PixelStreaming {
      * console commands.
      * @returns true if succeeded, false if rejected
      */
-    public sendConsoleCommand(command: string) {
+    public emitConsoleCommand(command: string) {
         if (!this.allowConsoleCommands || !this._webRtcController.videoPlayer.isVideoReady()) {
             return false;
         }
-        this._webRtcController.sendConsoleCommand(command);
+        this._webRtcController.emitConsoleCommand(command);
         return true;
     }
 

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -570,11 +570,11 @@ export class PixelStreaming {
      * and any serializable plain JSON objects with no recurrence can be sent.
      * @returns true if succeeded, false if rejected
      */
-    public sendUIInteraction(descriptor: object) {
+    public emitUIInteraction(descriptor: object) {
         if (!this._webRtcController.videoPlayer.isVideoReady()) {
             return false;
         }
-        this._webRtcController.sendUIInteraction(descriptor);
+        this._webRtcController.emitUIInteraction(descriptor);
         return true;
     }
 

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -570,7 +570,7 @@ export class PixelStreaming {
      * and any serializable plain JSON objects with no recurrence can be sent.
      * @returns true if succeeded, false if rejected
      */
-    public emitUIInteraction(descriptor: object) {
+    public emitUIInteraction(descriptor: object | string) {
         if (!this._webRtcController.videoPlayer.isVideoReady()) {
             return false;
         }

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -596,7 +596,7 @@ export class PixelStreaming {
      * @param name - The name of the response handler
      * @param listener - The method to be activated when a message is received
      */
-    addResponseEventListener(
+    public addResponseEventListener(
         name: string,
         listener: (response: string) => void
     ) {
@@ -607,7 +607,7 @@ export class PixelStreaming {
      * Remove a UE -> browser response event listener
      * @param name - The name of the response handler
      */
-    removeResponseEventListener(name: string) {
+    public removeResponseEventListener(name: string) {
         this._webRtcController.responseController.removeResponseEventListener(name);
     }
 

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -595,6 +595,19 @@ export class PixelStreaming {
     }
 
     /**
+     * Send a console command to UE application. Only allowed if UE has signaled that it allows
+     * console commands.
+     * @returns true if succeeded, false if rejected
+     */
+    public emitConsoleCommand(command: string) {
+        if (!this.allowConsoleCommands || !this._webRtcController.videoPlayer.isVideoReady()) {
+            return false;
+        }
+        this._webRtcController.emitConsoleCommand(command);
+        return true;
+    }
+
+    /**
      * Add a UE -> browser response event listener
      * @param name - The name of the response handler
      * @param listener - The method to be activated when a message is received

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -591,7 +591,27 @@ export class PixelStreaming {
         return true;
     }
 
-	/**
+    /**
+     * Add a UE -> browser response event listener
+     * @param name - The name of the response handler
+     * @param listener - The method to be activated when a message is received
+     */
+    addResponseEventListener(
+        name: string,
+        listener: (response: string) => void
+    ) {
+        this._webRtcController.responseController.addResponseEventListener(name, listener);
+    }
+
+    /**
+     * Remove a UE -> browser response event listener
+     * @param name - The name of the response handler
+     */
+    removeResponseEventListener(name: string) {
+        this._webRtcController.responseController.removeResponseEventListener(name);
+    }
+
+    /**
      * Dispatch a new event.
      * @param e event
      * @returns

--- a/Frontend/library/src/UeInstanceMessage/SendDescriptorController.ts
+++ b/Frontend/library/src/UeInstanceMessage/SendDescriptorController.ts
@@ -36,7 +36,7 @@ export class SendDescriptorController {
      * Send a Latency Test to the UE Instance
      * @param descriptor - the descriptor for a UI Interaction
      */
-    emitUIInteraction(descriptor: object) {
+    emitUIInteraction(descriptor: object | string) {
         this.sendDescriptor('UIInteraction', descriptor);
     }
 
@@ -45,7 +45,7 @@ export class SendDescriptorController {
      * @param messageType - UE Message Type
      * @param descriptor - Descriptor Message as JSON
      */
-    sendDescriptor(messageType: string, descriptor: object) {
+    sendDescriptor(messageType: string, descriptor: object | string) {
         // Convert the descriptor object into a JSON string.
         const descriptorAsString = JSON.stringify(descriptor);
         const toStreamerMessages =

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1671,6 +1671,9 @@ export class WebRtcPlayerController {
         this.streamMessageController.toStreamerHandlers.get('IFrameRequest')();
     }
 
+    /**
+     * Send a UIInteraction message
+     */
     sendUIInteraction(descriptor: object) {
         Logger.Log(
             Logger.GetStackTrace(),
@@ -1678,6 +1681,20 @@ export class WebRtcPlayerController {
             6
         );
         this.sendDescriptorController.emitUIInteraction(descriptor);
+    }
+
+    /**
+     * Send a console command message
+     */
+    sendConsoleCommand(command: string) {
+        Logger.Log(
+            Logger.GetStackTrace(),
+            '----   Sending custom Command:ConsoleCommand message   ----',
+            6
+        );
+        this.sendDescriptorController.emitCommand({
+            ConsoleCommand: command,
+        });
     }
 
     /**

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1674,7 +1674,7 @@ export class WebRtcPlayerController {
     /**
      * Send a UIInteraction message
      */
-    sendUIInteraction(descriptor: object) {
+    emitUIInteraction(descriptor: object) {
         Logger.Log(
             Logger.GetStackTrace(),
             '----   Sending custom UIInteraction message   ----',

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1671,6 +1671,15 @@ export class WebRtcPlayerController {
         this.streamMessageController.toStreamerHandlers.get('IFrameRequest')();
     }
 
+    sendUIInteraction(descriptor: object) {
+        Logger.Log(
+            Logger.GetStackTrace(),
+            '----   Sending custom UIInteraction message   ----',
+            6
+        );
+        this.sendDescriptorController.emitUIInteraction(descriptor);
+    }
+
     /**
      * Sends a request to the UE Instance to have ownership of Quality
      */

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1684,17 +1684,15 @@ export class WebRtcPlayerController {
     }
 
     /**
-     * Send a console command message
+     * Send a Command message
      */
-    emitConsoleCommand(command: string) {
+    emitCommand(descriptor: object) {
         Logger.Log(
             Logger.GetStackTrace(),
-            '----   Sending custom Command:ConsoleCommand message   ----',
+            '----   Sending custom Command message   ----',
             6
         );
-        this.sendDescriptorController.emitCommand({
-            ConsoleCommand: command,
-        });
+        this.sendDescriptorController.emitCommand(descriptor);
     }
 
     /**

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1674,7 +1674,7 @@ export class WebRtcPlayerController {
     /**
      * Send a UIInteraction message
      */
-    emitUIInteraction(descriptor: object) {
+    emitUIInteraction(descriptor: object | string) {
         Logger.Log(
             Logger.GetStackTrace(),
             '----   Sending custom UIInteraction message   ----',

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1686,7 +1686,7 @@ export class WebRtcPlayerController {
     /**
      * Send a console command message
      */
-    sendConsoleCommand(command: string) {
+    emitConsoleCommand(command: string) {
         Logger.Log(
             Logger.GetStackTrace(),
             '----   Sending custom Command:ConsoleCommand message   ----',

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1696,6 +1696,20 @@ export class WebRtcPlayerController {
     }
 
     /**
+     * Send a console command message
+     */
+    emitConsoleCommand(command: string) {
+        Logger.Log(
+            Logger.GetStackTrace(),
+            '----   Sending custom Command:ConsoleCommand message   ----',
+            6
+        );
+        this.sendDescriptorController.emitCommand({
+            ConsoleCommand: command,
+        });
+    }
+
+    /**
      * Sends a request to the UE Instance to have ownership of Quality
      */
     sendRequestQualityControlOwnership(): void {


### PR DESCRIPTION
# Summary

Adds support for browser <-> UE communication through the API:
- `emitUIInteraction(data: object | string)`:
    - sends arbitrary data as an `UIInteraction` message
- `emitCommand(descriptor: object)`:
    - sends a Command message 
    - if the descriptor contains a `ConsoleCommand`, it is permitted only if the UE app has been started with`-AllowPixelStreamingCommands` command line argument
- `emitConsoleCommand(command: string)`:
    - sends a ConsoleCommand message 
    - permitted only if the UE app has been started with `-AllowPixelStreamingCommands` command line argument
- `addResponseEventListener(name, funct)` / `removeResponseEventListener(name)`:
    - register/remove a listener that is triggered when receiving UE -> browser messages

# Test plan

## Browser <-> UE
- Modified UE Pixel Streaming application to do the following:
   - Monitors for any incoming browser -> UE messages that contain the string `EchoBack`
   - If one received, send back a response with content `EchoResponse: $originalMessage`
![blueprint](https://user-images.githubusercontent.com/8232602/222142069-21e428ea-2594-41ae-b01b-b7cb1f8aa4f4.png)
- Modified `uiless.ts` to do the following:
   - Sends a `UIInteraction` message starting with `EchoBack` 10 seconds after page has been opened
   - Logs any responses received from UE
![Screenshot 2023-03-01 at 13 55 30](https://user-images.githubusercontent.com/8232602/222142310-f3b49bf8-64dc-4c3d-ab45-0216eaf4bb8f.png)
- Started uiless.html and waited for 10 seconds
- Verified that the browser -> UE and UE -> browser messages were both logged, ensuring that communication works both ways
![Screenshot 2023-03-01 at 13 42 55](https://user-images.githubusercontent.com/8232602/222142437-2ba0ef45-b26a-46eb-9daf-9ccb6b071801.png)

## Custom commands
- Started a Pixel Streaming UE app with command line parameter `-AllowPixelStreamingCommands`
- Added some code to `uiless.ts` to toggle FPS counter and degrade video quality 10 seconds after initialization:
```
setTimeout(() => {
	pixelStreaming.emitCommand({
		ConsoleCommand: "stat fps",
	});
	pixelStreaming.emitCommand({
		"Encoder.MinQP": 51,
	});
}, 10000);
```
- Opened `uiless.html`, waited for 10 seconds, and verified that FPS counter was enabled and video quality was degraded
![Screenshot 2023-02-28 at 9 28 26](https://user-images.githubusercontent.com/8232602/222142919-ea9054d2-0cc5-4ce5-b8b1-a0f9313fff84.png)
![Screenshot 2023-03-02 at 9 05 52](https://user-images.githubusercontent.com/8232602/222357251-a490097a-a644-4999-a763-f4f138e230c4.png)

- Repeated the test with `-AllowPixelStreamingCommands` command line arg disabled
- Verified that FPS counter was not enabled after 10 seconds, since the console command was rejected. Video was still degraded as expected
