### PR TITLE
Fix datachannels when using an SFU

### DIFF
--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -307,6 +307,8 @@ class Player {
 			return;
 		}
 
+		// normally we want to indicate what player this message came from
+		// but in some instances we might already have set this (streamerDataChannels) due to poor choices
 		if (!message.playerId) {
 			message.playerId = this.id;
 		}

--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -307,7 +307,9 @@ class Player {
 			return;
 		}
 
-		message.playerId = this.id;
+		if (!message.playerId) {
+			message.playerId = this.id;
+		}
 		const msgString = JSON.stringify(message);
 
 		let streamer = streamers.get(this.streamerId);
@@ -439,8 +441,8 @@ function forwardStreamerMessageToPlayer(streamer, msg) {
 	const playerId = getPlayerIdFromMessage(msg);
 	const player = players.get(playerId);
 	if (player) {
-		logForward(streamer.id, playerId, msg);
 		delete msg.playerId;
+		logForward(streamer.id, playerId, msg);
 		player.sendTo(msg);
 	}
 }


### PR DESCRIPTION
This fixes the issue where only the last joined peer could interact with the given streamer so now all peers should be able to interact by default.
The problem was that the new signalling server was making some assumptions about messages being sent from players and would unconditionally add the playerId field to the message with the sending player. Unfortunately the streamerDataChannels message used that field to specify the id of the player we were creating the data channel for. Without this fix, the data channel would always get the player id of the SFU and not the requesting player.