### PR TITLE
Clean up on Pixel Streaming session disconnect

### DIFF
--- a/Frontend/library/src/AFK/AFKController.ts
+++ b/Frontend/library/src/AFK/AFKController.ts
@@ -76,7 +76,7 @@ export class AFKController {
     stopAfkWarningTimer() {
         this.active = false;
         this.countdownActive = false;
-        clearInterval(this.warnTimer);
+        clearTimeout(this.warnTimer);
         clearInterval(this.countDownTimer);
     }
 

--- a/Frontend/library/src/Inputs/MouseController.ts
+++ b/Frontend/library/src/Inputs/MouseController.ts
@@ -134,6 +134,15 @@ export class MouseController {
         this.mouseEventListenerTracker.addUnregisterCallback(
             () => lockedMouseEvents.unregisterMouseEvents()
         );
+        this.mouseEventListenerTracker.addUnregisterCallback(() => {
+            if (
+                document.exitPointerLock &&
+                (document.pointerLockElement === videoElementParent ||
+                    document.mozPointerLockElement === videoElementParent)
+            ) {
+                document.exitPointerLock();
+            }
+        });
     }
 
     /**

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1520,14 +1520,14 @@ export class WebRtcPlayerController {
      * Close the Connection to the signaling server
      */
     closeSignalingServer() {
-        this.webSocketController.close();
+        this.webSocketController?.close();
     }
 
     /**
      * Close the peer connection
      */
     closePeerConnection() {
-        this.peerConnectionController.close();
+        this.peerConnectionController?.close();
     }
 
     /**

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -209,6 +209,12 @@ export class WebRtcPlayerController {
             if (this.statsTimerHandle && this.statsTimerHandle !== undefined) {
                 window.clearInterval(this.statsTimerHandle);
             }
+
+            // unregister all input device event handlers on disconnect
+            this.setTouchInputEnabled(false);
+            this.setMouseInputEnabled(false);
+            this.setKeyboardInputEnabled(false);
+            this.setGamePadInputEnabled(false);
         });
 
         // set up the final webRtc player controller methods from within our application so a connection can be activated

--- a/Frontend/library/src/WebSockets/WebSocketController.ts
+++ b/Frontend/library/src/WebSockets/WebSocketController.ts
@@ -201,7 +201,7 @@ export class WebSocketController {
      * Closes the Websocket connection
      */
     close() {
-        this.webSocket.close();
+        this.webSocket?.close();
     }
 
     /** Event used for Displaying websocket closed messages */


### PR DESCRIPTION
# Summary

The Pixel Streaming library should clean up after it has finished a session. This helps integrating the lib within a single-page-app like a React app, where you might have the user navigate from a Pixel Streaming view to other views without a page refresh.

The current code leaves e.g. dangling event handlers connected to `videoParent` and `document` element, which it should clean up when not required any more. One of the symptoms of these dangling event handlers is a lot of console logging after disconnected whenever mouse or keyboard events are emitted:
![Screenshot 2023-03-07 at 12 26 49](https://user-images.githubusercontent.com/8232602/223491078-f3169ce9-2917-4d7c-acb7-9ba6692fc7b9.png)

This PR performs the following clean up tasks when the library has closed the session:
- Unregister all user input event handlers when disconnecting
   - These are registered again always on reconnecting, so it makes it symmetric if unregistering on disconnecting
- Use `clearTimeout`, not `clearInterval` to clear AFK timeout since it's not an interval
   - (actually in some browsers `clearInterval` accidentally clears also timeouts if called with a timeout id because of underlying implementation details, but this is not something guaranteed for all browsers)
- Added `exitPointerLock()` call to pointer lock mouse handler teardown
   - Exits pointer lock when disconnecting, but also if the lock happens to be active when some external API call toggles mouse input off or switches to hovering mouse event handler
- Also made `pixelStreaming.disconnect()` more robust by adding `undefined` checks
   - It previously crashed if `disconnect()` was called before connection was established. Got hit by this when implementing a test React app if navigating quickly out of the Pixel Streaming view before the connection was fully up

# Test Plan

## AFK timetout
- Opened a Pixel Streaming session with AFK timeout enabled
- Disconnected the UE app before the AFK timeout was triggered
- Waited and verified that the timeout was not triggered after disconnected

## Unregister event handlers on disconnecting
- Opened a Pixel Streaming session in `uiless.html`
- Listed the event handlers connected to `videoParentElement` and `document`, and saw a bunch of event handlers
![Screenshot 2023-03-07 at 12 50 07](https://user-images.githubusercontent.com/8232602/223493444-a09ba9f8-7b32-4590-9bde-4b8151856b22.png)
- Used the API to auto-disconnect after 10 seconds
![Screenshot 2023-03-07 at 12 51 26](https://user-images.githubusercontent.com/8232602/223493526-cdb36d16-5f2f-44c0-899e-1224fcffa876.png)
- After disconnected listed the event handlers again and verified that all had been cleared
![Screenshot 2023-03-07 at 12 50 35](https://user-images.githubusercontent.com/8232602/223493573-78ccca2e-f6a3-4d5b-be27-a834242d9cd5.png)
- Moved mouse around and pressed keyboard keys. Verified that there were no more console messages printed by the event handlers

- Retested the above by disconnecting from UE side, not through API. Verified that the event handlers were cleared also on UE side disconnect

- Used `player.html` to verify that disconnecting & reconnecting multiple times re-established the event handlers every time the connection was established. Verified that user input worked as expected after multiple reconnections

## Pointer lock
- Opened a Pixel Streaming session with pointer lock mouse handler
- Clicked the video to lock mouse cursor
- Disconnected the UE app to trigger disconnect actions
- Verified that the pointer lock was released when disconnecting
