### PR TITLE
Pass HTTPS certificate locations via Cirrus configuration

### DIFF
--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -18,6 +18,8 @@ const defaultConfig = {
 	UseFrontend: false,
 	UseMatchmaker: false,
 	UseHTTPS: false,
+	HTTPSCertFile: './certificates/client-cert.pem',
+	HTTPSKeyFile: './certificates/client-key.pem',
 	UseAuthentication: false,
 	LogToFile: true,
 	LogVerbose: true,
@@ -50,8 +52,8 @@ var http = require('http').Server(app);
 if (config.UseHTTPS) {
 	//HTTPS certificate details
 	const options = {
-		key: fs.readFileSync(path.join(__dirname, './certificates/client-key.pem')),
-		cert: fs.readFileSync(path.join(__dirname, './certificates/client-cert.pem'))
+		key: fs.readFileSync(path.join(__dirname, config.HTTPSKeyFile)),
+		cert: fs.readFileSync(path.join(__dirname, config.HTTPSCertFile))
 	};
 
 	var https = require('https').Server(options, app);


### PR DESCRIPTION
This change adds two new fields to cirrus configuration file: `HTTPSCertFile` and `HTTPSKeyFile`. Those are relative file locations of certificate files used to establish secure HTTPS connection by the Cirrus server.

Thanks to this change I'm able to keep certificate files outside of `PixelStreamingInfrastructure` project location.

The default values for the new fields point to previous default certificate files locations, so if the new parameters are not provided, the app haves the same way as before.