### PR TITLE
Fix: controller indices from multiple peers would clash

### DIFF
--- a/Frontend/library/src/DataChannel/InitialSettings.ts
+++ b/Frontend/library/src/DataChannel/InitialSettings.ts
@@ -30,7 +30,6 @@ export class InitialSettings {
 export class PixelStreamingSettings {
     AllowPixelStreamingCommands?: boolean;
     DisableLatencyTest?: boolean;
-	PlayerId?: number;
 }
 
 /**

--- a/Frontend/library/src/DataChannel/InitialSettings.ts
+++ b/Frontend/library/src/DataChannel/InitialSettings.ts
@@ -30,6 +30,7 @@ export class InitialSettings {
 export class PixelStreamingSettings {
     AllowPixelStreamingCommands?: boolean;
     DisableLatencyTest?: boolean;
+	PlayerId?: number;
 }
 
 /**

--- a/Frontend/library/src/Inputs/GamepadController.ts
+++ b/Frontend/library/src/Inputs/GamepadController.ts
@@ -69,6 +69,8 @@ export class GamePadController {
     unregisterGamePadEvents() {
         this.gamePadEventListenerTracker.unregisterAll();
         this.controllers = [];
+        this.onGamepadConnected = () => { /* */ };
+        this.onGamepadDisconnected = () => { /* */ };
     }
 
     /**
@@ -81,7 +83,8 @@ export class GamePadController {
 
         const temp: Controller = {
             currentState: gamepad,
-            prevState: gamepad
+            prevState: gamepad,
+            id: undefined
         };
 
         this.controllers.push(temp);
@@ -92,7 +95,8 @@ export class GamePadController {
             'gamepad: ' + gamepad.id + ' connected',
             6
         );
-        this.requestAnimationFrame(() => this.updateStatus());
+        window.requestAnimationFrame(() => this.updateStatus());
+        this.onGamepadConnected();
     }
 
     /**
@@ -106,10 +110,12 @@ export class GamePadController {
             'gamepad: ' + gamePadEvent.gamepad.id + ' disconnected',
             6
         );
+        const deletedController = this.controllers[gamePadEvent.gamepad.index];
         delete this.controllers[gamePadEvent.gamepad.index];
         this.controllers = this.controllers.filter(
             (controller) => controller !== undefined
         );
+        this.onGamepadDisconnected(deletedController.id);
     }
 
     /**
@@ -138,7 +144,8 @@ export class GamePadController {
 
         // Iterate over multiple controllers in the case the multiple gamepads are connected
         for (const controller of this.controllers) {
-            const controllerIndex = this.controllers.indexOf(controller);
+            // If we haven't received an id (possible if using an older version of UE), return to original functionality
+            const controllerIndex = (controller.id === undefined) ? this.controllers.indexOf(controller) : controller.id;
             const currentState = controller.currentState;
             for (let i = 0; i < controller.currentState.buttons.length; i++) {
                 const currentButton = controller.currentState.buttons[i];
@@ -217,7 +224,33 @@ export class GamePadController {
             this.requestAnimationFrame(() => this.updateStatus());
         }
     }
+
+    onGamepadResponseReceived(gamepadId: number) {
+        for(const controller of this.controllers) {
+            if(controller.id === undefined) {
+                controller.id = gamepadId;
+                break;
+            }
+        }
+    }
+
+    /**
+     * Event to send the gamepadconnected message to the application
+     */
+    onGamepadConnected() {
+        // Default Functionality: Do Nothing
+    }
+
+    /**
+     * Event to send the gamepaddisconnected message to the application
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onGamepadDisconnected(controllerIdx: number) {
+        // Default Functionality: Do Nothing
+    }
 }
+
+
 
 /**
  * Additional types for Window and Navigator

--- a/Frontend/library/src/Inputs/GamepadController.ts
+++ b/Frontend/library/src/Inputs/GamepadController.ts
@@ -68,6 +68,11 @@ export class GamePadController {
      */
     unregisterGamePadEvents() {
         this.gamePadEventListenerTracker.unregisterAll();
+        for(const controller of this.controllers) {
+            if(controller.id !== undefined) {
+                this.onGamepadDisconnected(controller.id);
+            }
+        }
         this.controllers = [];
         this.onGamepadConnected = () => { /* */ };
         this.onGamepadDisconnected = () => { /* */ };

--- a/Frontend/library/src/Inputs/GamepadTypes.ts
+++ b/Frontend/library/src/Inputs/GamepadTypes.ts
@@ -6,4 +6,5 @@
 export interface Controller {
     currentState: Gamepad;
     prevState: Gamepad;
+    id: number | undefined;
 }

--- a/Frontend/library/src/Inputs/XRGamepadController.ts
+++ b/Frontend/library/src/Inputs/XRGamepadController.ts
@@ -72,7 +72,8 @@ export class XRGamepadController {
             if (this.controllers[handedness] === undefined) {
                 this.controllers[handedness] = {
                     prevState: undefined,
-                    currentState: undefined
+                    currentState: undefined,
+					id: undefined
                 };
                 this.controllers[handedness].prevState =
                     WebXRUtils.deepCopyGamepad(source.gamepad);

--- a/Frontend/library/src/UeInstanceMessage/StreamMessageController.ts
+++ b/Frontend/library/src/UeInstanceMessage/StreamMessageController.ts
@@ -176,6 +176,11 @@ export class StreamMessageController {
             structure: ['uint8', 'uint16', 'uint16', 'uint8', 'uint8', 'uint8']
         });
         // Gamepad Input Messages. Range = 90..99
+        this.toStreamerMessages.add('GamepadConnected', {
+            id: 93,
+            byteLength: 0,
+            structure: []
+        });
         this.toStreamerMessages.add('GamepadButtonPressed', {
             id: 90,
             byteLength: 3,
@@ -194,6 +199,12 @@ export class StreamMessageController {
             //            ctrlerId   button  analogValue
             structure: ['uint8', 'uint8', 'double']
         });
+        this.toStreamerMessages.add('GamepadDisconnected', {
+            id: 94,
+            byteLength: 1,
+            //          ctrlerId
+            structure: ['uint8']
+        });
 
         this.fromStreamerMessages.add('QualityControlOwnership', 0);
         this.fromStreamerMessages.add('Response', 1);
@@ -208,6 +219,7 @@ export class StreamMessageController {
         this.fromStreamerMessages.add('FileContents', 10);
         this.fromStreamerMessages.add('TestEcho', 11);
         this.fromStreamerMessages.add('InputControlOwnership', 12);
+        this.fromStreamerMessages.add('GamepadResponse', 13);
         this.fromStreamerMessages.add('Protocol', 255);
     }
 


### PR DESCRIPTION
## Problem
When multiple peers are connected, each peer's controllers will increment from 0.

This means that if player 0 has 2 gamepads, they'll be assigned index 0 and index 1 and when player 1 connects with two gamepads of its own, they'll also be assigned index 0 and index 1 as illustrated below:

![image](https://user-images.githubusercontent.com/29305253/226233228-d65b8a1b-a0da-46f7-99c3-d0a5b4af8355.png)


## Solution
The most suitable solution to this problem would be for the Pixel Streaming module to keep track of all of the in-use gamepad indices. When a new gamepad is detected by the peer, it sends a request to the application for a gamepad index that is free. The application responds with an index to use and the peer will then use this provided controller index for any subsequent calls to the application.

## Compatibility
Backwards compatibility is preserved in this change by using the local controller index (the one that increments from 0) if the application doesn't provide the peer with an index. This case would happen if using a UE version less than 5.2 but using the latest frontend.
