### PR TITLE
Fix: sfu player would try subscribing when sfu disconnected

### DIFF
--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -561,7 +561,7 @@ function onSFUDisconnected() {
 	disconnectAllPlayers(SFUPlayerId);
 	const sfuPlayer = getSFU();
 	if (sfuPlayer) {
-		sfuPlayer.subscribe();
+		sfuPlayer.unsubscribe();
 		sfuPlayer.ws.close(4000, "SFU Disconnected");
 	}
 	players.delete(SFUPlayerId);


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
In Cirrus, when the SFU disconnects, the player representing the SFU would try and subscribe to the SFU. This is just a simple type, the player should instead unsubscribe.

## Solution
Fix the type. The player now unsubscribes on SFU disconnect.

Fixes https://github.com/EpicGames/PixelStreamingInfrastructure/issues/171

## Test Plan and Compatibility
Tested streaming both with and without the SFU. Checked that on SFU disconnect, the player will unsubscribe instead of subscribing.