### PR TITLE
Add support for programmatically changing peer layers when using the SFU

### DIFF
--- a/SFU/sfu_server.js
+++ b/SFU/sfu_server.js
@@ -44,7 +44,7 @@ async function onStreamerOffer(sdp) {
 }
 
 function getNextStreamerSCTPId() {
-	return streamer.transport._getNextSctpStreamId();
+    return streamer.transport._getNextSctpStreamId();
 }
 
 function onStreamerDisconnected() {
@@ -218,8 +218,17 @@ function disconnectAllPeers() {
   }
 }
 
+function onLayerPreference(msg) {
+  const peer = peers.get(`${msg.playerId}`);
+  if (peer != null) {
+    for (consumer of peer.consumers) {
+      consumer.setPreferredLayers({ spatialLayer: msg.spatialLayer, temporalLayer: msg.temporalLayer });
+    }
+  }
+}
+
 async function onSignallingMessage(message) {
-	//console.log(`Got MSG: ${message}`);
+    //console.log(`Got MSG: ${message}`);
   const msg = JSON.parse(message);
 
   if (msg.type == 'offer') {
@@ -243,9 +252,9 @@ async function onSignallingMessage(message) {
   else if (msg.type == 'peerDataChannelsReady') {
     setupStreamerDataChannelsForPeer(msg.playerId);
   }
-  // todo a new message type for force layer switch (for debugging)
-  // see: https://mediasoup.org/documentation/v3/mediasoup/api/#consumer-setPreferredLayers
-  // preferredLayers for debugging to select a particular simulcast layer, looks like { spatialLayer: 2, temporalLayer: 0 }
+  else if (msg.type == 'layerPreference') {
+    onLayerPreference(msg);
+  }
 }
 
 async function startMediasoup() {

--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -454,6 +454,14 @@ function onStreamerMessageDisconnectPlayer(streamer, msg) {
 	}
 }
 
+function onStreamerMessageLayerPreference(streamer, msg) {
+	let sfuPlayer = getSFU();
+	if (sfuPlayer) {
+		logOutgoing(sfuPlayer.id, msg);
+		sfuPlayer.sendTo(msg);
+	}
+}
+
 function forwardStreamerMessageToPlayer(streamer, msg) {
 	const playerId = getPlayerIdFromMessage(msg);
 	const player = players.get(playerId);
@@ -471,6 +479,7 @@ streamerMessageHandlers.set('offer', forwardStreamerMessageToPlayer);
 streamerMessageHandlers.set('answer', forwardStreamerMessageToPlayer);
 streamerMessageHandlers.set('iceCandidate', forwardStreamerMessageToPlayer);
 streamerMessageHandlers.set('disconnectPlayer', onStreamerMessageDisconnectPlayer);
+streamerMessageHandlers.set('layerPreference', onStreamerMessageLayerPreference);
 
 console.logColor(logging.Green, `WebSocket listening for Streamer connections on :${streamerPort}`)
 let streamerServer = new WebSocket.Server({ port: streamerPort, backlog: 1 });


### PR DESCRIPTION
## Relevant components:
- [X] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [X] SFU

## Problem statement:
Currently when utilising the SFU, players are switched to different resolution streams based on their prevailing network conditions.

It may be useful however, to force a specific player (or all players) to be on a specific layer. This could be useful during development to see how your stream will look at different resolutions without needing to use a third party tool such as NetLimiter to fake this poor network.

## Solution
This PR adds support for a new message from the application. This message is structured as follows:
```
{
    "type": "layerPreference",
    "playerId": "TargetPlayerId",
    "spatialLayer": N,
    "temporalLayer": M
}
```
The `playerId` value represents the id of the player whose layers you wish to change.

The `spatialLayer` value represents the resolution based layer, configured by the `SimulcastParameters` passed to the application at launch. If no value is passed, layer 0 represents full resolution and layer 1 represents half resolution.

The `temporalLayer` value represents the framerate based layer. Pixel Streaming currently doesn't support different temporal layers, but if/when support for it is added this value will become useful.

## Documentation
No SFU specific docs.

## Test Plan and Compatibility
Tested using the latest SFU and Cirrus to ensure a stream can still operate as expected. 

I also setup a key bind in an Unreal project to switch between layers. In this example, I passed three layers in the application by launching with `-SimulcastParameters=1.0,5000000,20000000,2.0,1000000,5000000,4.0,50000,1000000`. These three layers represent Full Res, Half Res and Quarter Res. My bind would then cycle through each layer on key press and set every player to this new layer.

![image](https://user-images.githubusercontent.com/29305253/228101291-ec43a388-5b99-4df3-a62b-9a3787a67184.png)
