### PR TITLE
Fix: Connecting to Unreal 5.1 app with the 5.2 frontend crashes on connect

### DIFF
--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -200,7 +200,13 @@ export class WebRtcPlayerController {
             this.setVideoEncoderAvgQP(0);
         };
         this.webSocketController.onOpen.addEventListener('open', () => {
-            this.webSocketController.requestStreamerList();
+            const BrowserSendsOffer = this.config.isFlagEnabled(
+                Flags.BrowserSendOffer
+            );
+            if(!BrowserSendsOffer)
+            {
+                this.webSocketController.requestStreamerList();
+            }
         });
         this.webSocketController.onClose.addEventListener('close', () => {
             this.afkController.stopAfkWarningTimer();
@@ -1126,24 +1132,6 @@ export class WebRtcPlayerController {
         }
         this.resizePlayerStyle();
     }
-
-    // buildSignallingServerUrl() {
-    //     let signallingServerUrl = this.config.getTextSettingValue(
-    //         TextParameters.SignallingServerUrl
-    //     );
-
-    //     // If we are connecting to the SFU add a special url parameter to the url
-    //     if (this.config.isFlagEnabled(Flags.BrowserSendOffer)) {
-    //         signallingServerUrl += '?' + Flags.BrowserSendOffer + '=true';
-    //     }
-
-    //     // This code is no longer needed, but is a good example for how subsequent config flags can be appended
-    //     // if (this.config.isFlagEnabled(Flags.BrowserSendOffer)) {
-    //     //     signallingServerUrl += (signallingServerUrl.includes('?') ? '&' : '?') + Flags.BrowserSendOffer + '=true';
-    //     // }
-
-    //     return signallingServerUrl;
-    // }
 
     /**
      * Connect to the Signaling server

--- a/SFU/sfu_server.js
+++ b/SFU/sfu_server.js
@@ -44,7 +44,7 @@ async function onStreamerOffer(sdp) {
 }
 
 function getNextStreamerSCTPId() {
-	return streamer.transport._getNextSctpStreamId();
+    return streamer.transport._getNextSctpStreamId();
 }
 
 function onStreamerDisconnected() {
@@ -218,8 +218,17 @@ function disconnectAllPeers() {
   }
 }
 
+function onLayerPreference(msg) {
+  const peer = peers.get(`${msg.playerId}`);
+  if (peer != null) {
+    for (consumer of peer.consumers) {
+      consumer.setPreferredLayers({ spatialLayer: msg.spatialLayer, temporalLayer: msg.temporalLayer });
+    }
+  }
+}
+
 async function onSignallingMessage(message) {
-	//console.log(`Got MSG: ${message}`);
+    //console.log(`Got MSG: ${message}`);
   const msg = JSON.parse(message);
 
   if (msg.type == 'offer') {
@@ -243,9 +252,9 @@ async function onSignallingMessage(message) {
   else if (msg.type == 'peerDataChannelsReady') {
     setupStreamerDataChannelsForPeer(msg.playerId);
   }
-  // todo a new message type for force layer switch (for debugging)
-  // see: https://mediasoup.org/documentation/v3/mediasoup/api/#consumer-setPreferredLayers
-  // preferredLayers for debugging to select a particular simulcast layer, looks like { spatialLayer: 2, temporalLayer: 0 }
+  else if (msg.type == 'layerPreference') {
+    onLayerPreference(msg);
+  }
 }
 
 async function startMediasoup() {

--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -454,6 +454,14 @@ function onStreamerMessageDisconnectPlayer(streamer, msg) {
 	}
 }
 
+function onStreamerMessageLayerPreference(streamer, msg) {
+	let sfuPlayer = getSFU();
+	if (sfuPlayer) {
+		logOutgoing(sfuPlayer.id, msg);
+		sfuPlayer.sendTo(msg);
+	}
+}
+
 function forwardStreamerMessageToPlayer(streamer, msg) {
 	const playerId = getPlayerIdFromMessage(msg);
 	const player = players.get(playerId);
@@ -471,6 +479,7 @@ streamerMessageHandlers.set('offer', forwardStreamerMessageToPlayer);
 streamerMessageHandlers.set('answer', forwardStreamerMessageToPlayer);
 streamerMessageHandlers.set('iceCandidate', forwardStreamerMessageToPlayer);
 streamerMessageHandlers.set('disconnectPlayer', onStreamerMessageDisconnectPlayer);
+streamerMessageHandlers.set('layerPreference', onStreamerMessageLayerPreference);
 
 console.logColor(logging.Green, `WebSocket listening for Streamer connections on :${streamerPort}`)
 let streamerServer = new WebSocket.Server({ port: streamerPort, backlog: 1 });

--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -83,7 +83,7 @@ if (config.UseFrontend) {
 
 	if (config.UseHTTPS && config.DisableSSLCert) {
 		//Required for self signed certs otherwise just get an error back when sending request to frontend see https://stackoverflow.com/a/35633993
-		console.warn('WARNING: config.DisableSSLCert is true. Unauthorized SSL certificates will be allowed! This is convenient for local testing but please DO NOT SHIP THIS IN PRODUCTION. To remove this warning please set DisableSSLCert to false in your config.json.');
+		console.logColor(logging.Orange, 'WARNING: config.DisableSSLCert is true. Unauthorized SSL certificates will be allowed! This is convenient for local testing but please DO NOT SHIP THIS IN PRODUCTION. To remove this warning please set DisableSSLCert to false in your config.json.');
 		process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"
 	}
 
@@ -320,7 +320,13 @@ class Player {
 
 	sendFrom(message) {
 		if (!this.streamerId) {
-			return;
+			if(streamers.size > 0) {
+				this.streamerId = streamers.entries().next().value[0];
+				console.logColor(logging.Orange, `Player ${this.id} attempted to send an outgoing message without having subscribed first. Defaulting to ${this.streamerId}`);
+			} else {
+				console.logColor(logging.Orange, `Player ${this.id} attempted to send an outgoing message without having subscribed first. No streamer connected so this message isn't going anywhere!`)
+				return;
+			}
 		}
 
 		// normally we want to indicate what player this message came from

--- a/SignallingWebServer/modules/logging.js
+++ b/SignallingWebServer/modules/logging.js
@@ -29,6 +29,7 @@ const Blue = '\x1b[34m';
 const Magenta = '\x1b[35m';
 const Cyan = '\x1b[36m';
 const White = '\x1b[37m';
+const Orange = '\x1b[38;5;215m';
 
 /**
  * Pad the start of the given number with zeros so it takes up the number of digits.
@@ -104,5 +105,6 @@ module.exports = {
 	Blue,
 	Magenta,
 	Cyan,
-	White
+	White,
+	Orange
 }


### PR DESCRIPTION
## Relevant components:
- [X] Signalling server
- [ ] Frontend library
- [X] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
This PR addresses https://github.com/EpicGames/PixelStreamingInfrastructure/issues/160. Using a UE version < 5.2 with latest infra would cause a crash.

## Solution
The root cause of the issue was that older versions of UE would always send offer on player connected, and player connected is caused by subscription which triggered by receiving a streamer list.

The solution in this case is to only request a streamer list if UE will be the one to send the offer. This does have the added side effect of the frontend not being able to work with multiple streamers when the browsers sends the offer.

This unfortunate drawback is required for cases such as Scalable Pixel Streaming where if we tried to request the streamer list, we would be met with no response and therefore never be able to subscribe.


## Test Plan and Compatibility
Tested with UE5.1 and 5.2 and on both versions testing with BrowserSendOffer both on and off. I also tested multi-streamer still worked with UE sending offer on 5.2