### PR TITLE
Moved all package.json under @epicgames-ps scope to avoid package confusion

### DIFF
--- a/Matchmaker/package.json
+++ b/Matchmaker/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "cirrus-matchmaker",
+  "name": "@epicgames-ps/cirrus-matchmaker",
   "version": "0.0.1",
+  "private": true,
   "description": "Cirrus servers connect to the Matchmaker which redirects a browser to the next available Cirrus server",
   "dependencies": {
     "cors": "^2.8.5",

--- a/SFU/mediasoup-sdp-bridge/package.json
+++ b/SFU/mediasoup-sdp-bridge/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "mediasoup-sdp-bridge",
+  "name": "@epicgames-ps/mediasoup-sdp-bridge",
+  "private": true,
   "version": "3.6.5",
   "description": "Node.js library to allow integration of SDP based clients with mediasoup",
   "contributors": [

--- a/SFU/package.json
+++ b/SFU/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "pixelstreaming-sfu",
+  "name": "@epicgames-ps/pixelstreaming-sfu",
   "version": "1.0.0",
   "description": "Reference implementation for a PixelStreaming SFU",
+  "private": true,
   "scripts": {
     "start-local": "run-script-os --",
       "start-local:windows": ".\\platform_scripts\\cmd\\run.bat",

--- a/SignallingWebServer/package.json
+++ b/SignallingWebServer/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "cirrus-webserver",
+  "name": "@epicgames-ps/cirrus-webserver",
   "version": "0.0.1",
   "description": "The reference signalling and web server for Pixel Streaming: Cirrus",
+  "private": true,
   "scripts": {
     "store_password": "run-script-os",
     "store_password:default": "./platform_scripts/bash/node/bin/node ./modules/authentication/db/store_password.js --usersFile=./modules/authentication/db/users.json",


### PR DESCRIPTION
Some package were unscoped in this repository and could be published to look like they were the official distributions.

## Relevant components:
- [x] Signalling server
- [x] Matchmaker
- [x] SFU

## Problem statement:
This PR moves all `package.json` to have a scope that we control so they cannot be published by thirdparties.

## Solution
Adds the scope @epicgame-ps to the `package.json` files and introduces the field `private: true` to the relevant unpublished packages.

## Test Plan and Compatibility
These packages are intended to be unpublished anyway, so I mostly ensured they continued to build by running the appropriate launch scripts.
