### PR TITLE
Added exports for UI configuration types

### DIFF
--- a/Frontend/ui-library/src/pixelstreamingfrontend-ui.ts
+++ b/Frontend/ui-library/src/pixelstreamingfrontend-ui.ts
@@ -1,6 +1,6 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
-export { Application, UIOptions } from './Application/Application';
+export { Application, UIOptions, VideoQPIndicatorConfig } from './Application/Application';
 
 export { PixelStreamingApplicationStyle } from './Styles/PixelStreamingApplicationStyles';
 
@@ -19,3 +19,4 @@ export { SettingUIFlag } from './Config/SettingUIFlag';
 export { SettingUINumber } from './Config/SettingUINumber';
 export { SettingUIOption } from './Config/SettingUIOption';
 export { SettingUIText } from './Config/SettingUIText';
+export { PanelConfiguration, UIElementConfig, UIElementCreationMode } from './UI/UIConfigurationTypes'


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Frontend library
- [x] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Some types which I added before weren't exported in the module.ts file, which was making it impossible to use them when the module is imported from npm.

## Solution
They are now exported.

## Documentation
None needed.

## Test Plan and Compatibility
None needed.