### PR TITLE
Alter reconnection flow to request streamer message list and fail out after N attempts.

### DIFF
--- a/Frontend/Docs/Settings Panel.md
+++ b/Frontend/Docs/Settings Panel.md
@@ -26,7 +26,7 @@ This page will be updated with new features and commands as they become availabl
 | **Suppress browser keys** | Suppress or allow certain keys we use in UE, for example F5 to show shader complexity instead of refreshing the page. |
 | **AFK if Idle** | Timeout the connection if no input is detected for a period of time. |
 | **AFK timeout** | Allows you to specify the AFK timeout period. |
-
+| **Max Reconnects** | The maximum number of reconnects the application will attempt when a streamer disconnects. |
 
 ### UI
 | **Setting** | **Description** |

--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -53,7 +53,7 @@ export class NumericParameters {
     static WebRTCFPS = 'WebRTCFPS' as const;
     static WebRTCMinBitrate = 'WebRTCMinBitrate' as const;
     static WebRTCMaxBitrate = 'WebRTCMaxBitrate' as const;
-	static MaxReconnectAttempts = 'MaxReconnectAttempts' as const;
+    static MaxReconnectAttempts = 'MaxReconnectAttempts' as const;
 }
 
 export type NumericParametersKeys = Exclude<
@@ -387,7 +387,7 @@ export class Config {
                 'Either locked mouse, where the pointer is consumed by the video and locked to it, or hovering mouse, where the mouse is not consumed.',
                 false,
                 useUrlParams,
-				(isHoveringMouse: boolean, setting: SettingBase) => {
+                (isHoveringMouse: boolean, setting: SettingBase) => {
                     setting.label = `Control Scheme: ${isHoveringMouse ? 'Hovering' : 'Locked'} Mouse`;
                 }
             )
@@ -476,7 +476,7 @@ export class Config {
             )
         );
 
-		this.numericParameters.set(
+        this.numericParameters.set(
             NumericParameters.MaxReconnectAttempts,
             new SettingNumber(
                 NumericParameters.MaxReconnectAttempts,

--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -53,6 +53,7 @@ export class NumericParameters {
     static WebRTCFPS = 'WebRTCFPS' as const;
     static WebRTCMinBitrate = 'WebRTCMinBitrate' as const;
     static WebRTCMaxBitrate = 'WebRTCMaxBitrate' as const;
+	static MaxReconnectAttempts = 'MaxReconnectAttempts' as const;
 }
 
 export type NumericParametersKeys = Exclude<
@@ -240,7 +241,7 @@ export class Config {
                 })(),
                 useUrlParams
             )
-        );
+        );	
 
         /**
          * Boolean parameters
@@ -471,6 +472,19 @@ export class Config {
                 0 /*min*/,
                 600 /*max*/,
                 120 /*value*/,
+                useUrlParams
+            )
+        );
+
+		this.numericParameters.set(
+            NumericParameters.MaxReconnectAttempts,
+            new SettingNumber(
+                NumericParameters.MaxReconnectAttempts,
+                'Max Reconnects',
+                'Maximum number of reconnects the application will attempt when a streamer disconnects.',
+                0 /*min*/,
+                999 /*max*/,
+                3 /*value*/,
                 useUrlParams
             )
         );

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.test.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.test.ts
@@ -176,7 +176,8 @@ describe('PixelStreaming', () => {
     });
 
     it('should disconnect and reconnect to signalling server if reconnect is called and connection is up', () => {
-        const config = new Config({ initialSettings: {ss: mockSignallingUrl, AutoConnect: true}});
+        // We explicitly set the max reconnect attempts to 0 to stop the auto-reconnect flow as that is tested separate
+        const config = new Config({ initialSettings: {ss: mockSignallingUrl, AutoConnect: true, MaxReconnectAttempts: 0}});
         const autoconnectedSpy = jest.fn();
         const pixelStreaming = new PixelStreaming(config);
         pixelStreaming.addEventListener("webRtcAutoConnect", autoconnectedSpy);
@@ -195,6 +196,56 @@ describe('PixelStreaming', () => {
         expect(webSocketSpyFunctions.constructorSpy).toHaveBeenCalledWith(mockSignallingUrl);
         expect(webSocketSpyFunctions.constructorSpy).toHaveBeenCalledTimes(2);
         expect(autoconnectedSpy).toHaveBeenCalled();
+    });
+
+    it('should automatically reconnect and request streamer list N times on websocket close', () => {
+        const config = new Config({ initialSettings: {ss: mockSignallingUrl, AutoConnect: true, MaxReconnectAttempts: 3}});
+        const autoconnectedSpy = jest.fn();
+
+        const pixelStreaming = new PixelStreaming(config);
+        pixelStreaming.addEventListener("webRtcAutoConnect", autoconnectedSpy);
+
+        expect(webSocketSpyFunctions.constructorSpy).toHaveBeenCalledWith(mockSignallingUrl);
+        expect(webSocketSpyFunctions.constructorSpy).toHaveBeenCalledTimes(1);
+        expect(webSocketSpyFunctions.closeSpy).not.toHaveBeenCalled();
+
+        pixelStreaming.disconnect();
+
+        expect(webSocketSpyFunctions.closeSpy).toHaveBeenCalled();
+
+        // wait 2 seconds
+        jest.advanceTimersByTime(2000);
+
+        // we should have attempted a reconnection
+        expect(webSocketSpyFunctions.constructorSpy).toHaveBeenCalledWith(mockSignallingUrl);
+        expect(webSocketSpyFunctions.constructorSpy).toHaveBeenCalledTimes(2);
+        // Reconnect triggers the first list streamer message
+        triggerWebSocketOpen();
+        expect(webSocketSpyFunctions.sendSpy).toHaveBeenCalledWith(
+            expect.stringMatching(/"type":"listStreamers"/)
+        );
+        // We don't have a signalling server to respond with data so lets just fake a response with no streamers
+        triggerStreamerListMessage([]);
+        // Wait 2 seconds. This delay waits for the WebRtcPlayerController to realise the previously received list doesn't contain
+        // the streamer is was preiously subscribed to, so it'll request the list again
+        jest.advanceTimersByTime(2000);
+
+        // Same as above but repeated for the second call
+        expect(webSocketSpyFunctions.sendSpy).toHaveBeenCalledWith(
+            expect.stringMatching(/"type":"listStreamers"/)
+        );
+        triggerStreamerListMessage([]);
+        jest.advanceTimersByTime(2000);
+
+        // Expect the third call
+        expect(webSocketSpyFunctions.sendSpy).toHaveBeenCalledWith(
+            expect.stringMatching(/"type":"listStreamers"/)
+        );
+        triggerStreamerListMessage([]);
+        jest.advanceTimersByTime(2000);
+
+        // We should expect only 3 calls based on our config
+        expect(webSocketSpyFunctions.sendSpy).toHaveBeenCalledTimes(3);
     });
 
     it('should request streamer list when connected to the signalling server', () => {

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -227,8 +227,9 @@ export class WebRtcPlayerController {
             this.setKeyboardInputEnabled(false);
             this.setGamePadInputEnabled(false);
 
-            if(this.shouldReconnect) {
+            if(this.shouldReconnect && this.config.getNumericSettingValue(NumericParameters.MaxReconnectAttempts) > 0) {
                 this.isReconnecting = true;
+                this.reconnectAttempt++;
                 this.restartStreamAutomatically();
             }
         });

--- a/Frontend/ui-library/src/Config/ConfigUI.ts
+++ b/Frontend/ui-library/src/Config/ConfigUI.ts
@@ -202,7 +202,7 @@ export class ConfigUI {
             psSettingsSection,
             this.numericParametersUi.get(NumericParameters.AFKTimeoutSecs)
         );
-		this.addSettingNumeric(
+        this.addSettingNumeric(
             psSettingsSection,
             this.numericParametersUi.get(NumericParameters.MaxReconnectAttempts)
         );

--- a/Frontend/ui-library/src/Config/ConfigUI.ts
+++ b/Frontend/ui-library/src/Config/ConfigUI.ts
@@ -202,6 +202,10 @@ export class ConfigUI {
             psSettingsSection,
             this.numericParametersUi.get(NumericParameters.AFKTimeoutSecs)
         );
+		this.addSettingNumeric(
+            psSettingsSection,
+            this.numericParametersUi.get(NumericParameters.MaxReconnectAttempts)
+        );
 
         /* Setup all view/ui related settings under this section */
         const viewSettingsSection = this.buildSectionWithHeading(


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [X] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU


## Problem statement:
When disconnected from a stream, the frontend would make no attempt to reconnect. This causes Virtual Cameras to never reconnect when changing target viewport.

To test this yourself (using 5.2):
1) Add 2 VCam Actors
2) Give both Streams their respective IDs, eg Stream 1 and Stream 2 (keep note of which is which)
3) Ensure both are set to Target Viewport 1 (as they would be by default)
4) Connect tab one to Stream 1
5) Connect a new tab Stream 2
6) Change Stream 2 to target Viewport 2 (do not disable VCamActor first)

You'll notice that Stream 2 will temporarily stop and then restart when it changes viewport.


## Solution
This issue has been addressed by altering web socket disconnects to enable a reconnection flow. When a web socket connection is closed by way of a streamer disconnecting, the frontend will reconnect to the signalling server and request the streamer list a maximum of N times to see if the streamer it was previously connected to has come back. In this case, N can be configured with `MaxReconnectAttempts` URL parameter or appropriate option in the settings panel.

If the streamer comes back within the N attempts, the frontend will automatically subscribe. Otherwise, if the streamer doesn't reconnect, the frontend will close the web socket connection and a user will be taken back to the original 'Click To Start' landing page.


## Documentation
Updated the Settings Panel document to reflect the new option.


## Test Plan and Compatibility
Added a unit test to test the new reconnection flow.
