### PR TITLE
Allow inheritance of webrtcPlayerController and webXrController

### DIFF
--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -42,8 +42,8 @@ export interface PixelStreamingOverrides {
  * this will likely be the core of your Pixel Streaming experience in terms of functionality.
  */
 export class PixelStreaming {
-    private _webRtcController: WebRtcPlayerController;
-    private _webXrController: WebXRController;
+    protected _webRtcController: WebRtcPlayerController;
+    protected _webXrController: WebXRController;
     /**
      * Configuration object. You can read or modify config through this object. Whenever
      * the configuration is changed, the library will emit a `settingsChanged` event.


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
This PR addresses the problem of the `webRtcPlayerController` member being too restricted, preventing users from overriding some of its functionality.

## Solution
This PR addresses makes the `webRtcPlayerController` member protected, allowing users to override its functionality by extending the `PixelStreaming` class first.

## Documentation
None

## Test Plan and Compatibility
No testing required as PR is trivial.

An example use of this functionality can be seen below:

```
class MessageExtendedConfig extends MessageRecv {
    peerConnectionOptions: RTCConfiguration;
    engineVersion: string
};

class ExtendedStreaming extends PixelStreaming {
    // Create a new method that retains original functionality
    public handleOnConfig(messageExtendedConfig: MessageExtendedConfig) {
        this._webRtcController.handleOnConfigMessage(messageConfig)
    }
};

document.body.onload = function() {
    const config = new Config({ useUrlParams: true });
    const extendedStream = new ExtendedStreaming(config);
    extendedStream.webSocketController.onConfig = (messageExtendedConfig: MessageExtendedConfig ) => {
        // Override the original listener, do our extended functionality and then call the original method
        extendedStream.config.setFlagEnabled(Flags.BrowserSendOffer, (messageExtendedConfig.engineVersion === "4"));
        
        extendedStream.handleOnConfig(messageExtendedConfig);
    }
}
```
