### PR TITLE
Yovel/dev

### DIFF
--- a/Frontend/library/package-lock.json
+++ b/Frontend/library/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2",
-    "version": "0.2.0",
+    "version": "0.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2",
-            "version": "0.2.0",
+            "version": "0.5.0",
             "license": "MIT",
             "dependencies": {
                 "sdp": "^3.1.0"
@@ -26,7 +26,7 @@
                 "typedoc": "^0.23.24",
                 "typescript": "^4.9.4",
                 "webpack": "^5.75.0",
-                "webpack-cli": "^5.0.1"
+                "webpack-cli": "^5.0.2"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1902,9 +1902,9 @@
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.1.tgz",
-            "integrity": "sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.2.tgz",
+            "integrity": "sha512-S9h3GmOmzUseyeFW3tYNnWS7gNUuwxZ3mmMq0JyW78Vx1SGKPSkt5bT4pB0rUnVfHjP0EL9gW2bOzmtiTfQt0A==",
             "dev": true,
             "engines": {
                 "node": ">=14.15.0"
@@ -6515,17 +6515,17 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.1.tgz",
-            "integrity": "sha512-S3KVAyfwUqr0Mo/ur3NzIp6jnerNpo7GUO6so51mxLi1spqsA17YcMXy0WOIJtBSnj748lthxC6XLbNKh/ZC+A==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.2.tgz",
+            "integrity": "sha512-4y3W5Dawri5+8dXm3+diW6Mn1Ya+Dei6eEVAdIduAmYNLzv1koKVAqsfgrrc9P2mhrYHQphx5htnGkcNwtubyQ==",
             "dev": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.0.1",
                 "@webpack-cli/info": "^2.0.1",
-                "@webpack-cli/serve": "^2.0.1",
+                "@webpack-cli/serve": "^2.0.2",
                 "colorette": "^2.0.14",
-                "commander": "^9.4.1",
+                "commander": "^10.0.1",
                 "cross-spawn": "^7.0.3",
                 "envinfo": "^7.7.3",
                 "fastest-levenshtein": "^1.0.12",
@@ -6560,12 +6560,12 @@
             }
         },
         "node_modules/webpack-cli/node_modules/commander": {
-            "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
             "dev": true,
             "engines": {
-                "node": "^12.20.0 || >=14"
+                "node": ">=14"
             }
         },
         "node_modules/webpack-merge": {
@@ -8310,9 +8310,9 @@
             "requires": {}
         },
         "@webpack-cli/serve": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.1.tgz",
-            "integrity": "sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.2.tgz",
+            "integrity": "sha512-S9h3GmOmzUseyeFW3tYNnWS7gNUuwxZ3mmMq0JyW78Vx1SGKPSkt5bT4pB0rUnVfHjP0EL9gW2bOzmtiTfQt0A==",
             "dev": true,
             "requires": {}
         },
@@ -11742,17 +11742,17 @@
             }
         },
         "webpack-cli": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.1.tgz",
-            "integrity": "sha512-S3KVAyfwUqr0Mo/ur3NzIp6jnerNpo7GUO6so51mxLi1spqsA17YcMXy0WOIJtBSnj748lthxC6XLbNKh/ZC+A==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.2.tgz",
+            "integrity": "sha512-4y3W5Dawri5+8dXm3+diW6Mn1Ya+Dei6eEVAdIduAmYNLzv1koKVAqsfgrrc9P2mhrYHQphx5htnGkcNwtubyQ==",
             "dev": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.0.1",
                 "@webpack-cli/info": "^2.0.1",
-                "@webpack-cli/serve": "^2.0.1",
+                "@webpack-cli/serve": "^2.0.2",
                 "colorette": "^2.0.14",
-                "commander": "^9.4.1",
+                "commander": "^10.0.1",
                 "cross-spawn": "^7.0.3",
                 "envinfo": "^7.7.3",
                 "fastest-levenshtein": "^1.0.12",
@@ -11763,9 +11763,9 @@
             },
             "dependencies": {
                 "commander": {
-                    "version": "9.5.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-                    "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+                    "version": "10.0.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+                    "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
                     "dev": true
                 }
             }

--- a/Frontend/library/package.json
+++ b/Frontend/library/package.json
@@ -29,7 +29,7 @@
         "typedoc": "^0.23.24",
         "typescript": "^4.9.4",
         "webpack": "^5.75.0",
-        "webpack-cli": "^5.0.1"
+        "webpack-cli": "^5.0.2"
     },
     "dependencies": {
         "sdp": "^3.1.0"

--- a/Frontend/library/src/Inputs/KeyboardController.ts
+++ b/Frontend/library/src/Inputs/KeyboardController.ts
@@ -153,12 +153,16 @@ export class KeyboardController {
         const keyDownHandler = (ev: KeyboardEvent) => this.handleOnKeyDown(ev);
         const keyUpHandler = (ev: KeyboardEvent) => this.handleOnKeyUp(ev);
         const keyPressHandler = (ev: KeyboardEvent) => this.handleOnKeyPress(ev);
+        const handleOnBlur = () => this.handleOnBlur();
 
+        
         document.addEventListener("keydown", keyDownHandler);
         document.addEventListener("keyup", keyUpHandler);
-
+        
         //This has been deprecated as at Jun 13 2021
         document.addEventListener("keypress", keyPressHandler);
+        
+        window.addEventListener("blur", handleOnBlur)
 
         this.keyboardEventListenerTracker.addUnregisterCallback(
             () => document.removeEventListener("keydown", keyDownHandler)
@@ -169,6 +173,9 @@ export class KeyboardController {
         this.keyboardEventListenerTracker.addUnregisterCallback(
             () => document.removeEventListener("keypress", keyPressHandler)
         );
+        this.keyboardEventListenerTracker.addUnregisterCallback(
+            () => document.removeEventListener("blur", handleOnBlur)
+        );
     }
 
     /**
@@ -178,6 +185,24 @@ export class KeyboardController {
         this.keyboardEventListenerTracker.unregisterAll();
     }
 
+    /**
+     * Unregisters activeKeys on current document is out of focus (switch between tabs etc)
+    */
+    handleOnBlur() {
+        const activeKeys = this.activeKeysProvider.getActiveKeys();
+
+        activeKeys.forEach(keyCode => {
+            Logger.Log(Logger.GetStackTrace(), `Unregister key ${keyCode}`, 6);
+              
+            const toStreamerHandlers =
+                this.toStreamerMessagesProvider.toStreamerHandlers;
+            toStreamerHandlers.get('KeyUp')([
+                keyCode,
+                0
+            ]);
+        })
+    }
+    
     /**
      * Handles When a key is down
      * @param keyboardEvent - Keyboard event

--- a/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
+++ b/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
@@ -19,7 +19,8 @@ import { Logger } from '../Logger/Logger';
  * The Aggregated Stats that is generated from the RTC Stats Report
  */
 
-type RTCStatsTypePS = RTCStatsType | 'stream';
+type RTCStatsTypePS = RTCStatsType | 'stream' | 'media-playout';
+
 export class AggregatedStats {
     inboundVideoStats: InboundVideoStats;
     inboundAudioStats: InboundAudioStats;
@@ -75,6 +76,7 @@ export class AggregatedStats {
                     this.handleLocalCandidate(stat);
                     break;
                 case 'media-source':
+                case 'media-playout':
                     break;
                 case 'outbound-rtp':
                     break;
@@ -97,7 +99,7 @@ export class AggregatedStats {
                     this.handleStream(stat);
                     break;
                 default:
-                    Logger.Error(Logger.GetStackTrace(), 'unhandled Stat Type');
+                    Logger.Error(Logger.GetStackTrace(), 'unhandled Stat Type' + type);
                     Logger.Log(Logger.GetStackTrace(), stat);
                     break;
             }

--- a/Frontend/library/webpack.dev.js
+++ b/Frontend/library/webpack.dev.js
@@ -4,6 +4,7 @@ const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 
 const devCommon = {
+  watch: true,
   mode: 'development',
   devtool: 'inline-source-map',
   devServer: {

--- a/Frontend/ui-library/package-lock.json
+++ b/Frontend/ui-library/package-lock.json
@@ -24,7 +24,7 @@
                 "typedoc": "^0.23.24",
                 "typescript": "^4.9.4",
                 "webpack": "^5.75.0",
-                "webpack-cli": "^5.0.1"
+                "webpack-cli": "^5.0.2"
             },
             "peerDependencies": {
                 "@epicgames-ps/lib-pixelstreamingfrontend-ue5.2": "^0.5.0"
@@ -811,9 +811,9 @@
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.1.tgz",
-            "integrity": "sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.2.tgz",
+            "integrity": "sha512-S9h3GmOmzUseyeFW3tYNnWS7gNUuwxZ3mmMq0JyW78Vx1SGKPSkt5bT4pB0rUnVfHjP0EL9gW2bOzmtiTfQt0A==",
             "dev": true,
             "engines": {
                 "node": ">=14.15.0"
@@ -3434,17 +3434,17 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.1.tgz",
-            "integrity": "sha512-S3KVAyfwUqr0Mo/ur3NzIp6jnerNpo7GUO6so51mxLi1spqsA17YcMXy0WOIJtBSnj748lthxC6XLbNKh/ZC+A==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.2.tgz",
+            "integrity": "sha512-4y3W5Dawri5+8dXm3+diW6Mn1Ya+Dei6eEVAdIduAmYNLzv1koKVAqsfgrrc9P2mhrYHQphx5htnGkcNwtubyQ==",
             "dev": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.0.1",
                 "@webpack-cli/info": "^2.0.1",
-                "@webpack-cli/serve": "^2.0.1",
+                "@webpack-cli/serve": "^2.0.2",
                 "colorette": "^2.0.14",
-                "commander": "^9.4.1",
+                "commander": "^10.0.1",
                 "cross-spawn": "^7.0.3",
                 "envinfo": "^7.7.3",
                 "fastest-levenshtein": "^1.0.12",
@@ -3479,12 +3479,12 @@
             }
         },
         "node_modules/webpack-cli/node_modules/commander": {
-            "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
             "dev": true,
             "engines": {
-                "node": "^12.20.0 || >=14"
+                "node": ">=14"
             }
         },
         "node_modules/webpack-merge": {
@@ -4226,9 +4226,9 @@
             "requires": {}
         },
         "@webpack-cli/serve": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.1.tgz",
-            "integrity": "sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.2.tgz",
+            "integrity": "sha512-S9h3GmOmzUseyeFW3tYNnWS7gNUuwxZ3mmMq0JyW78Vx1SGKPSkt5bT4pB0rUnVfHjP0EL9gW2bOzmtiTfQt0A==",
             "dev": true,
             "requires": {}
         },
@@ -6135,17 +6135,17 @@
             }
         },
         "webpack-cli": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.1.tgz",
-            "integrity": "sha512-S3KVAyfwUqr0Mo/ur3NzIp6jnerNpo7GUO6so51mxLi1spqsA17YcMXy0WOIJtBSnj748lthxC6XLbNKh/ZC+A==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.2.tgz",
+            "integrity": "sha512-4y3W5Dawri5+8dXm3+diW6Mn1Ya+Dei6eEVAdIduAmYNLzv1koKVAqsfgrrc9P2mhrYHQphx5htnGkcNwtubyQ==",
             "dev": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.0.1",
                 "@webpack-cli/info": "^2.0.1",
-                "@webpack-cli/serve": "^2.0.1",
+                "@webpack-cli/serve": "^2.0.2",
                 "colorette": "^2.0.14",
-                "commander": "^9.4.1",
+                "commander": "^10.0.1",
                 "cross-spawn": "^7.0.3",
                 "envinfo": "^7.7.3",
                 "fastest-levenshtein": "^1.0.12",
@@ -6156,9 +6156,9 @@
             },
             "dependencies": {
                 "commander": {
-                    "version": "9.5.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-                    "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+                    "version": "10.0.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+                    "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
                     "dev": true
                 }
             }

--- a/Frontend/ui-library/package.json
+++ b/Frontend/ui-library/package.json
@@ -26,7 +26,7 @@
         "typedoc": "^0.23.24",
         "typescript": "^4.9.4",
         "webpack": "^5.75.0",
-        "webpack-cli": "^5.0.1"
+        "webpack-cli": "^5.0.2"
     },
     "dependencies": {
         "jss": "^10.9.2",


### PR DESCRIPTION
## Relevant components:
- [] Frontend library
- [] Frontend UI library

## Problem statement:
What problem does this PR address?
- When the pixel stream is running, and you click on some keyboard key and then go out of focus from the browser current tab or document (like switching tabs with ctrl + tab), the Ctrl keydown event will handle, but it will stay handled forever because the keyup could not detect after the website is not on focus. 

## Solution
How does this PR solve the problem?

By register a new browser event: "blur", when this event is triggered it looping over the activeKeys and call to keyUp registered function for all of those events. 

## Documentation
If you added a new feature or changed an existing feature please add some documentation here.

Or better yet, link to the relevant `/Docs` update in your PR.

## Test Plan and Compatibility
What steps have you taken to ensure this PR maintains compataibility with the existing functionality? 

Or better yet, link to the unit tests that accompany this PR.
