### PR TITLE
Fix: Reconnects will be attempted even when a disconnect is triggered by afk timeout

### DIFF
--- a/Frontend/library/src/PixelStreaming/PixelStreaming.test.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.test.ts
@@ -209,7 +209,7 @@ describe('PixelStreaming', () => {
         expect(webSocketSpyFunctions.constructorSpy).toHaveBeenCalledTimes(1);
         expect(webSocketSpyFunctions.closeSpy).not.toHaveBeenCalled();
 
-        pixelStreaming.disconnect();
+        pixelStreaming.webSocketController.close();
 
         expect(webSocketSpyFunctions.closeSpy).toHaveBeenCalled();
 

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -42,8 +42,8 @@ export interface PixelStreamingOverrides {
  * this will likely be the core of your Pixel Streaming experience in terms of functionality.
  */
 export class PixelStreaming {
-    private _webRtcController: WebRtcPlayerController;
-    private _webXrController: WebXRController;
+    protected _webRtcController: WebRtcPlayerController;
+    protected _webXrController: WebXRController;
     /**
      * Configuration object. You can read or modify config through this object. Whenever
      * the configuration is changed, the library will emit a `settingsChanged` event.

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1589,6 +1589,8 @@ export class WebRtcPlayerController {
      * Close the Connection to the signaling server
      */
     closeSignalingServer() {
+        // We explicitly called close, therefore we don't want to trigger auto reconnect
+        this.shouldReconnect = false;
         this.webSocketController?.close();
     }
 


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
This PR addresses https://github.com/EpicGames/PixelStreamingInfrastructure/issues/203.

## Solution
When programmatically closing the websocket connection, we set the `shouldReconnect` bool to false, indicating that the webRtcPlayerController should no attempt to auto reconnect.

## Documentation
No updates needed.

## Test Plan and Compatibility
Testing completed by triggering a stream restart on the frontend and observed the auto reconnect functionality not being triggered.

Also triggered the reconnect flow and observed it still worked as expected.