### PR TITLE
TURN server readme updates v5.0

### DIFF
--- a/SignallingWebServer/platform_scripts/bash/README.txt
+++ b/SignallingWebServer/platform_scripts/bash/README.txt
@@ -1,12 +1,13 @@
 How to use files in this directory:
-- Make sure that all of your dependencies are installed.  Use ./setup.sh what will install whatever is missing as long as you are on a supported operating system.  Please note that setup.sh is called from every script designed to run
 
-- Run a local instance of the Cirrus server by using the ./run_local.sh script
-
-- Use the following scripts to run locally or in your cloud instance:
- - Start_SignallingServer.sh  - Start only the Signalling (STUN) server
- - Start_TURNServer.sh - Start only the TURN server
- - Start_WithTURN_SignallingServer.sh - Start a TURN server and the Cirrus server together
+- Run ./setup.sh to automatically install all required dependencies for your operating system. Note that setup.sh is called from every script designed to run;
+- Run a local instance of the Cirrus server by using the ./run_local.sh script;
+- Use the following scripts to run locally or on your cloud instance (note that TURN server is not expected to work locally due to the nature of its application):
+   - Start_SignallingServer.sh  - start only the Signalling (STUN) server;
+   - Start_TURNServer.sh - start only the TURN server;
+   - Start_WithTURN_SignallingServer.sh - start a TURN server and the Cirrus server together.
+   
+Tips:
 
 - Please note that scripts intended to run need to be executable:  $ chmod +x *.sh  will do that job.
-- The local/cloud Start_*.sh shell scripts can be invoked with the  --help  command line option to see how those can be configured.  The following options can be supplied: --publicip, --turn, --stun.  Please read the --help
+- The local/cloud Start_*.sh shell scripts can be invoked with the  --help  command line option to see how those can be configured.  The following options can be supplied: --publicip, --turn, --stun.  Please read the --help.

--- a/SignallingWebServer/platform_scripts/cmd/README.txt
+++ b/SignallingWebServer/platform_scripts/cmd/README.txt
@@ -1,13 +1,14 @@
 How to use files in this directory:
-- Files with .ps1 extension can be run with PowerShell[.exe] in Windows.  Powershell needs to be started as Administrator to run setup.ps1 so it can run installation / installation check steps
-- Make sure that all of your dependencies are installed.  Use .\setup.ps1 what will install whatever is missing as long as you are on a supported operating system
 
-- Run a local instance of the Cirrus server by using the .\run_local.ps1 script
+- Files with .ps1 extension can be run with PowerShell[.exe] in Windows. Powershell needs to be started as Administrator to run setup.ps1 so it can run installation / installation check steps;
+- Run .\setup.bat to automatically install all required dependencies for your operating system. Note that .\setup.bat is called from every script designed to run;
+- Run a local instance of the Cirrus server by using the .\run_local.ps1 script;
+- Use the following scripts to run locally or on your cloud instance (note that TURN server is not expected to work locally due to the nature of its application):
+   - Start_SignallingServer.ps1 - start only the Signalling (STUN) server;
+   - Start_TURNServer.ps1 - start only the TURN server;
+   - Start_WithTURN_SignallingServer.ps1 - start a TURN server and the Cirrus server together;
 
-- Use the following scripts to run locally or in your cloud instance:
- - Start_SignallingServer.ps1 - Start only the Signalling (STUN) server
- - Start_TURNServer.ps1 - Start only the TURN server
- - Start_WithTURN_SignallingServer.ps1 - Start a TURN server and the Cirrus server together
-- The Start_Common.ps1 file contains shared functions for other Start_*.ps1 scripts and it is not supposed to run alone
+Tips:
 
-- The local/cloud Start_*.ps1 powershell scripts can be invoked with the  --help  command line option to see how those can be configured.  The following options can be supplied: --publicip, --turn, --stun.  Please read the --help
+- The Start_Common.ps1 file contains shared functions for other Start_*.ps1 scripts and it is not supposed to run alone.
+- The local/cloud Start_*.ps1 powershell scripts can be invoked with the  --help  command line option to see how those can be configured.  The following options can be supplied: --publicip, --turn, --stun.  Please read the --help.


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU
- [x] Documentation

## Documentation
Cleaned up README files for Signalling Server and updated them to say that TURN won't work locally.
