### PR TITLE
Added "media-playout" to prevent spam in Aggregated Stats

### DIFF
--- a/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
+++ b/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
@@ -19,7 +19,7 @@ import { Logger } from '../Logger/Logger';
  * The Aggregated Stats that is generated from the RTC Stats Report
  */
 
-type RTCStatsTypePS = RTCStatsType | 'stream';
+type RTCStatsTypePS = RTCStatsType | 'stream' | 'media-playout';
 export class AggregatedStats {
     inboundVideoStats: InboundVideoStats;
     inboundAudioStats: InboundAudioStats;

--- a/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
+++ b/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
@@ -76,6 +76,8 @@ export class AggregatedStats {
                     break;
                 case 'media-source':
                     break;
+                case 'media-playout':
+                    break;
                 case 'outbound-rtp':
                     break;
                 case 'peer-connection':


### PR DESCRIPTION
## Relevant components:
- [x ] Frontend library

## Problem statement:
Many browser versions don't yet support the "media-playout" stats type which causes flooding spam in the console, making it impossible to debug. This is a simple fix to stop that.

See: [media-playout](https://developer.mozilla.org/en-US/docs/Web/API/RTCStatsReport)

## Solution
Default cases it out like similar other stats. Also it appears Typescript hasn't updated their definition of RTCStatsType enum to include "media-playout" yet. That's annoying.