### PR TITLE
Fixing matchmaker directing users to http when the signalling server is using https

### DIFF
--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -820,7 +820,7 @@ if (config.UseMatchmaker) {
 		message = {
 			type: 'connect',
 			address: typeof serverPublicIp === 'undefined' ? '127.0.0.1' : serverPublicIp,
-			port: httpPort,
+			port: config.UseHTTPS ? httpsPort : httpPort,
 			ready: streamers.size > 0,
 			playerConnected: playerConnected
 		};


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
When the signalling server is configured to use HTTPS the matchmaker would still direct the users to the HTTP port. See #207 

## Solution
When the signalling server starts and communicates with the matchmaker it now supplies the correct HTTP or HTTPS port based on config.UseHTTPS allowing the matchmaker to redirect users to the correct port.

## Test Plan and Compatibility
Run the matchmaker with or without HTTPS and attempt running the signalling server with and without UseHTTPS configurations. Make sure that the matchmaker directs the user to the correct port and the streaming application runs as expected.
