### PR TITLE
Fixing hovering mouse mode set in URL being overridden on refresh.

### DIFF
--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1857,10 +1857,10 @@ export class WebRtcPlayerController {
                 parsedInitialSettings.PixelStreaming;
         }
 
-        if (parsedInitialSettings.ConfigOptions) {
+        if (parsedInitialSettings.ConfigOptions && !!parsedInitialSettings.ConfigOptions.DefaultToHover) {
             this.config.setFlagEnabled(
                 Flags.HoveringMouseMode,
-                !!parsedInitialSettings.ConfigOptions.DefaultToHover
+                true
             );
         }
 

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1857,10 +1857,10 @@ export class WebRtcPlayerController {
                 parsedInitialSettings.PixelStreaming;
         }
 
-        if (parsedInitialSettings.ConfigOptions && !!parsedInitialSettings.ConfigOptions.DefaultToHover) {
+        if (parsedInitialSettings.ConfigOptions && parsedInitialSettings.ConfigOptions.DefaultToHover !== undefined) {
             this.config.setFlagEnabled(
                 Flags.HoveringMouseMode,
-                true
+                !!parsedInitialSettings.ConfigOptions.DefaultToHover
             );
         }
 


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
When setting the mouse mode via the URL the frontend will ignore it when setting initial settings even if the initial settings don't include a value for it. See #222

## Solution
We only set the mouse mode if the setting exists in the initial settings.

## Test Plan and Compatibility
Check that the UI setting is changing the mouse mode. Then check that the URL setting is setting the mouse mode, even on refresh. Then check that an application can set the mouse mode with the initial settings. This can override the URL.
