### PR TITLE
Fixing viewport resizing not always working due to improperly calling timer.

### DIFF
--- a/Frontend/library/src/VideoPlayer/VideoPlayer.ts
+++ b/Frontend/library/src/VideoPlayer/VideoPlayer.ts
@@ -210,7 +210,7 @@ export class VideoPlayer {
         }
 
         const now = new Date().getTime();
-        if (now - this.lastTimeResized > 1000) {
+        if (now - this.lastTimeResized > 300) {
             const videoElementParent = this.getVideoParentElement();
             if (!videoElementParent) {
                 return;
@@ -230,8 +230,8 @@ export class VideoPlayer {
             );
             clearTimeout(this.resizeTimeoutHandle);
             this.resizeTimeoutHandle = window.setTimeout(
-                () => this.updateVideoStreamSize,
-                1000
+                () => this.updateVideoStreamSize(),
+                100
             );
         }
     }


### PR DESCRIPTION

## Relevant components:
- [ ] Signalling server
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Sometimes when resizing the viewport with the match viewport resolution option turned on, the application will not properly resize. See #239 

## Solution
When the resize event comes in too fast, the resize is offloaded to a timer but the timer was not properly calling the resize function. This just fixes the call. The times have also been slightly adjusted to make it feel a little more responsive.
