### PR TITLE
Changed forwarded logs to Cyan, added warning for missing playerId

### DIFF
--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -380,9 +380,9 @@ function logOutgoing(destName, msg) {
 
 function logForward(srcName, destName, msg) {
 	if (config.LogVerbose)
-		console.logColor(logging.Green, "\x1b[37m%s -> %s\x1b[32m %s", srcName, destName, JSON.stringify(msg));
+		console.logColor(logging.Cyan, "\x1b[37m%s -> %s\x1b[36m %s", srcName, destName, JSON.stringify(msg));
 	else
-		console.logColor(logging.Green, "\x1b[37m%s -> %s\x1b[32m %s", srcName, destName, msg.type);
+		console.logColor(logging.Cyan, "\x1b[37m%s -> %s\x1b[36m %s", srcName, destName, msg.type);
 }
 
 let WebSocket = require('ws');
@@ -475,6 +475,8 @@ function forwardStreamerMessageToPlayer(streamer, msg) {
 		delete msg.playerId;
 		logForward(streamer.id, playerId, msg);
 		player.sendTo(msg);
+	} else {
+		console.warning("No playerId specified, cannot forward message: %s", msg);
 	}
 }
 


### PR DESCRIPTION
## Relevant components:
- [X] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Logs from the signalling server are color-coded but do not distinguish between outgoing and forwarded messages. Furthermore, messages intended for forwarding are silently dropped if they don't specify a `playerId` for the intended recipient.

## Solution
Forwarded messages are now colored in cyan to distinguish them from outgoing messages in green. A warning is also logged to the console if a forwarded message is dropped due to not specifying a target.
