### PR TITLE
Re-enable iOS and iPadOS fullscreen

### DIFF
--- a/Frontend/ui-library/src/Application/Application.ts
+++ b/Frontend/ui-library/src/Application/Application.ts
@@ -194,7 +194,9 @@ export class Application {
             ? new FullScreenIconExternal(this._options.fullScreenControlsConfig.customElement)
             // Or use the one created by the Controls initializer earlier
             : controls.fullscreenIcon;
-        if (fullScreenButton) fullScreenButton.fullscreenElement = this.rootElement;
+        if (fullScreenButton) {
+            fullScreenButton.fullscreenElement = /iPhone|iPod/.test(navigator.userAgent) ? this.stream.videoElementParent.getElementsByTagName("video")[0] : this.rootElement;
+        }
 
         // Add settings button to controls
         const settingsButton : HTMLElement | undefined = 

--- a/Frontend/ui-library/src/UI/FullscreenIcon.ts
+++ b/Frontend/ui-library/src/UI/FullscreenIcon.ts
@@ -30,7 +30,7 @@ declare global {
  */
 export class FullScreenIconBase {
     isFullscreen = false;
-    fullscreenElement: HTMLElement;
+    fullscreenElement: HTMLElement | HTMLVideoElement;
 
     _rootElement: HTMLElement;
 


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Frontend library
- [X] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
This issue addresses https://github.com/EpicGames/PixelStreamingInfrastructure/issues/258, which states full screen on iOS has been broken since moving to the typescript frontend.

This regression is caused by iOS only allowing video elements to be full screened, whereas iPad and all other devices allow arbitrary html elements to become full screen. [source](https://developer.apple.com/forums/thread/133248)

## Solution
This PR addresses the problem by first checking the browsers user agents and if the device is an iPod or iPhone, we will only full screen the video element, otherwise we will full screen the parent div which contains all of the interactable UI. 

NOTE: As previously described, iPhones and iPods can't full screen arbitrary elements and as such requesting full screen will result in the video being played through the native player and input being prevented.

## Test Plan and Compatibility
Tested on an iPhone and iPad to confirm correct operation between devices.
