### PR TITLE
Fix iOS touch when settings panel is open

### DIFF
--- a/Frontend/library/src/Inputs/TouchController.ts
+++ b/Frontend/library/src/Inputs/TouchController.ts
@@ -41,9 +41,9 @@ export class TouchController implements ITouchController {
             this.onTouchEnd(ev);
         const ontouchmove = (ev: TouchEvent) =>
             this.onTouchMove(ev);
-        this.videoElementParent.addEventListener('touchstart', ontouchstart, { passive: false });
-        this.videoElementParent.addEventListener('touchend', ontouchend, { passive: false });
-        this.videoElementParent.addEventListener('touchmove', ontouchmove, { passive: false });
+        this.videoElementParent.addEventListener('touchstart', ontouchstart);
+        this.videoElementParent.addEventListener('touchend', ontouchend);
+        this.videoElementParent.addEventListener('touchmove', ontouchmove);
         this.touchEventListenerTracker.addUnregisterCallback(
             () => this.videoElementParent.removeEventListener('touchstart', ontouchstart)
         );
@@ -59,7 +59,7 @@ export class TouchController implements ITouchController {
         const preventOnTouchMove = (event: TouchEvent) => {
             event.preventDefault();
         };
-        document.addEventListener('touchmove', preventOnTouchMove, { passive: false });
+        document.addEventListener('touchmove', preventOnTouchMove);
         this.touchEventListenerTracker.addUnregisterCallback(
             () => document.removeEventListener('touchmove', preventOnTouchMove)
         );

--- a/Frontend/ui-library/src/Application/Application.ts
+++ b/Frontend/ui-library/src/Application/Application.ts
@@ -194,7 +194,9 @@ export class Application {
             ? new FullScreenIconExternal(this._options.fullScreenControlsConfig.customElement)
             // Or use the one created by the Controls initializer earlier
             : controls.fullscreenIcon;
-        if (fullScreenButton) fullScreenButton.fullscreenElement = this.rootElement;
+        if (fullScreenButton) {
+            fullScreenButton.fullscreenElement = /iPhone|iPod/.test(navigator.userAgent) ? this.stream.videoElementParent.getElementsByTagName("video")[0] : this.rootElement;
+        }
 
         // Add settings button to controls
         const settingsButton : HTMLElement | undefined = 

--- a/Frontend/ui-library/src/Styles/PixelStreamingApplicationStyles.ts
+++ b/Frontend/ui-library/src/Styles/PixelStreamingApplicationStyles.ts
@@ -240,12 +240,12 @@ export class PixelStreamingApplicationStyle {
             right: '0',
             height: '100%',
             minWidth: '20vw',
-            maxWidth: '100vw',
+            maxWidth: '90vw',
             transform: 'translateX(100%)',
             transition: '.3s ease-out',
             pointerEvents: 'all',
             backdropFilter: 'blur(10px)',
-            webkitBackdropFilter: 'blur(10px)',
+            '-webkit-backdrop-filter': 'blur(10px)',
             overflowY: 'auto',
             overflowX: 'hidden',
             backgroundColor: 'var(--color0)'
@@ -371,7 +371,7 @@ export class PixelStreamingApplicationStyle {
         },
         '.tgl, .tgl:after, .tgl:before, .tgl *, .tgl *:after, .tgl *:before, .tgl+.tgl-slider':
             {
-                webkitBoxSizing: 'border-box',
+                '-webkit-box-sizing': 'border-box',
                 boxSizing: 'border-box'
             },
         '.tgl::-moz-selection, .tgl:after::-moz-selection, .tgl:before::-moz-selection, .tgl *::-moz-selection, .tgl *:after::-moz-selection, .tgl *:before::-moz-selection, .tgl+.tgl-slider::-moz-selection':
@@ -407,14 +407,14 @@ export class PixelStreamingApplicationStyle {
         },
         '.tgl-flat+.tgl-slider': {
             padding: '2px',
-            webkitTransition: 'all .2s ease',
+            '-webkit-transition': 'all .2s ease',
             transition: 'all .2s ease',
             background: 'var(--color6)',
             border: '3px solid var(--color7)',
             borderRadius: '2em'
         },
         '.tgl-flat+.tgl-slider:after': {
-            webkitTransition: 'all .2s ease',
+            '-webkit-transition': 'all .2s ease',
             transition: 'all .2s ease',
             background: 'var(--color7)',
             content: '""',

--- a/Frontend/ui-library/src/UI/FullscreenIcon.ts
+++ b/Frontend/ui-library/src/UI/FullscreenIcon.ts
@@ -30,7 +30,7 @@ declare global {
  */
 export class FullScreenIconBase {
     isFullscreen = false;
-    fullscreenElement: HTMLElement;
+    fullscreenElement: HTMLElement | HTMLVideoElement;
 
     _rootElement: HTMLElement;
 


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [X] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Touch events weren't routed to panels once a video had started playing. This prevented modification of settings that we're not visible as you couldn't scroll to see them.

## Solution
Remove the passive aspect from touch handlers. This may have some negative impact on page performance but is necessary as the listeners we registers aren't passive.

## Test Plan and Compatibility
Tested on mobile platforms to ensure fix as well as desktop platforms to ensure no regressions
