### PR TITLE
Fix video res and frames dropped not updating in stats panel

### DIFF
--- a/SignallingWebServer/scripts/app.js
+++ b/SignallingWebServer/scripts/app.js
@@ -489,6 +489,11 @@ function onProtocolMessage(data) {
                         return;
                     }
 
+					if(messageType === "GamepadAnalog") {
+						// We don't want to update the GamepadAnalog message type as UE sends it with an incorrect bytelength
+						return;
+					}
+
                     if (toStreamerHandlers[messageType]) {
                         // If we've registered a handler for this message type we can add it to our supported messages. ie registerMessageHandler(...)
                         toStreamerMessages.add(messageType, message);

--- a/SignallingWebServer/scripts/webRtcPlayer.js
+++ b/SignallingWebServer/scripts/webRtcPlayer.js
@@ -360,6 +360,9 @@ function webRtcPlayer(parOptions) {
                     newStat.bytesReceived = stat.bytesReceived;
                     newStat.framesDecoded = stat.framesDecoded;
                     newStat.packetsLost = stat.packetsLost;
+                    newStat.frameHeight = stat.frameHeight;
+                    newStat.frameWidth = stat.frameWidth;
+                    newStat.framesDropped = stat.framesDropped;
                     newStat.bytesReceivedStart = self.aggregatedStats && self.aggregatedStats.bytesReceivedStart ? self.aggregatedStats.bytesReceivedStart : stat.bytesReceived;
                     newStat.framesDecodedStart = self.aggregatedStats && self.aggregatedStats.framesDecodedStart ? self.aggregatedStats.framesDecodedStart : stat.framesDecoded;
                     newStat.timestampStart = self.aggregatedStats && self.aggregatedStats.timestampStart ? self.aggregatedStats.timestampStart : stat.timestamp;


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
https://github.com/EpicGames/PixelStreamingInfrastructure/issues/277

## Solution
track stats are deprecated so we now get the info from `inbound-rtp` payload
