### PR TITLE
Show player count in stats panel

### DIFF
--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -25,7 +25,8 @@ import {
     WebRtcConnectingEvent,
     WebRtcDisconnectedEvent,
     WebRtcFailedEvent,
-    WebRtcSdpEvent
+    WebRtcSdpEvent,
+    PlayerCountEvent
 } from '../Util/EventEmitter';
 import { MessageOnScreenKeyboard } from '../WebSockets/MessageReceive';
 import { WebXRController } from '../WebXR/WebXRController';
@@ -558,6 +559,12 @@ export class PixelStreaming {
         this.config.setFlagEnabled(
             Flags.IsQualityController,
             hasQualityOwnership
+        );
+    }
+
+    _onPlayerCount(playerCount: number) {
+        this._eventEmitter.dispatchEvent(
+            new PlayerCountEvent({ count: playerCount })
         );
     }
 

--- a/Frontend/library/src/Util/EventEmitter.ts
+++ b/Frontend/library/src/Util/EventEmitter.ts
@@ -470,6 +470,21 @@ export class XrFrameEvent extends Event {
     }
 }
 
+/**
+ * An event that is emitted when receiving a player count from the signalling server
+ */
+export class PlayerCountEvent extends Event {
+    readonly type: 'playerCount';
+    readonly data: {
+        /** count object */
+        count: number
+    };
+    constructor(data: PlayerCountEvent['data']) {
+        super('playerCount');
+        this.data = data;
+    }
+}
+
 export type PixelStreamingEvent =
     | AfkWarningActivateEvent
     | AfkWarningUpdateEvent
@@ -502,7 +517,8 @@ export type PixelStreamingEvent =
     | SettingsChangedEvent
     | XrSessionStartedEvent
     | XrSessionEndedEvent
-    | XrFrameEvent;
+    | XrFrameEvent
+    | PlayerCountEvent;
 
 export class EventEmitter extends EventTarget {
     /**

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -204,6 +204,9 @@ export class WebRtcPlayerController {
             );
             this.setVideoEncoderAvgQP(0);
         };
+        this.webSocketController.onPlayerCount = (playerCount: MessageReceive.MessagePlayerCount) => { 
+            this.pixelStreaming._onPlayerCount(playerCount.count); 
+        };
         this.webSocketController.onOpen.addEventListener('open', () => {
             const BrowserSendsOffer = this.config.isFlagEnabled(
                 Flags.BrowserSendOffer

--- a/Frontend/library/src/WebSockets/SignallingProtocol.ts
+++ b/Frontend/library/src/WebSockets/SignallingProtocol.ts
@@ -108,6 +108,7 @@ export class SignallingProtocol {
                     'Player Count: ' + playerCount.count,
                     6
                 );
+                websocketController.onPlayerCount(playerCount)
             }
         );
 

--- a/Frontend/library/src/WebSockets/WebSocketController.ts
+++ b/Frontend/library/src/WebSockets/WebSocketController.ts
@@ -247,7 +247,12 @@ export class WebSocketController {
      * @param messageDataChannels - The data channels details
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-    onWebRtcPeerDataChannels(
-        messageDataChannels: MessageReceive.MessagePeerDataChannels
-    ) {}
+    onWebRtcPeerDataChannels(messageDataChannels: MessageReceive.MessagePeerDataChannels) {}
+
+    /**
+     * Event is fired when the websocket receives the an updated player count from cirrus
+     * @param MessagePlayerCount - The new player count
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+    onPlayerCount(playerCount: MessageReceive.MessagePlayerCount) {}
 }

--- a/Frontend/ui-library/src/Application/Application.ts
+++ b/Frontend/ui-library/src/Application/Application.ts
@@ -365,6 +365,11 @@ export class Application {
             'settingsChanged',
             (event) => this.configUI.onSettingsChanged(event)
         );
+        this.stream.addEventListener(
+            'playerCount', 
+            ({ data: { count }}) => 
+                this.onPlayerCount(count)
+        );
     }
 
     /**
@@ -660,6 +665,10 @@ export class Application {
 
     onLatencyTestResults(latencyTimings: LatencyTestResults) {
         this.statsPanel.latencyTest.handleTestResult(latencyTimings);
+    }
+
+    onPlayerCount(playerCount: number) {
+        this.statsPanel.handlePlayerCount(playerCount);
     }
 
     handleStreamerListMessage(messageStreamingList: MessageStreamerList, autoSelectedStreamerId: string | null) {

--- a/Frontend/ui-library/src/UI/StatsPanel.ts
+++ b/Frontend/ui-library/src/UI/StatsPanel.ts
@@ -147,6 +147,14 @@ export class StatsPanel {
         }
     }
 
+    public handlePlayerCount(playerCount: number) {
+        this.addOrUpdateStat(
+            'PlayerCountStat',
+            'Players',
+            playerCount.toString()
+        );
+    }
+
     /**
      * Handle stats coming in from browser/UE
      * @param stats the stats structure


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [X] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Player count information is simply logged to the developer console but is never shown in any UI, making it harder for non-technical users to view this information as reported in https://github.com/EpicGames/PixelStreamingInfrastructure/issues/302

## Solution
Add a new `playerCount` event that user's can listen to. By default, UI Library will listen for this event and update the value in the stats panel.