### PR TITLE
Add github action for PR and Issue management

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,9 +13,9 @@ jobs:
     - uses: actions/stale@v7
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Issues go stale after 90d of inactivity. Please comment or re-open the issue if you are still interested in getting this issue fixed.'
-        stale-pr-message: 'PRs go stale after 90d of inactivity. Please comment or re-open the PR if you are still working on this PR.'
+        stale-issue-message: 'Issues go stale after 30 days of inactivity. Please comment or re-open the issue if you are still interested in getting this issue fixed.'
+        stale-pr-message: 'PRs go stale after 30 days of inactivity. Please comment or re-open the PR if you are still working on this PR.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
-        days-before-stale: 90
+        days-before-stale: 30
         exempt-issue-labels: 'ignore-no-issue-activity'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v7
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Issues go stale after 90d of inactivity. Please comment or re-open the issue if you are still interested in getting this issue fixed.'
+        stale-pr-message: 'PRs go stale after 90d of inactivity. Please comment or re-open the PR if you are still working on this PR.'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        days-before-stale: 90
+        exempt-issue-labels: 'ignore-no-issue-activity'


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Some issues sit for a long time with no activity leading to bloat and noise. 

## Solution
Add an action to mark a PRs and Issues as stale if there's been no activity in over 90 days.
