### PR TITLE
Ensure touch is relative to absolute location of parent rect

### DIFF
--- a/Frontend/library/src/Inputs/TouchController.ts
+++ b/Frontend/library/src/Inputs/TouchController.ts
@@ -152,16 +152,15 @@ export class TouchController implements ITouchController {
         if (!this.videoElementProvider.isVideoReady()) {
             return;
         }
-        const videoElementParent =
-            this.videoElementProvider.getVideoParentElement();
+        const offset = this.videoElementProvider.getVideoParentElement().getBoundingClientRect();
         const toStreamerHandlers =
             this.toStreamerMessagesProvider.toStreamerHandlers;
 
         for (let t = 0; t < touches.length; t++) {
             const numTouches = 1; // the number of touches to be sent this message
             const touch = touches[t];
-            const x = touch.clientX - videoElementParent.offsetLeft;
-            const y = touch.clientY - videoElementParent.offsetTop;
+            const x = touch.clientX - offset.left;
+            const y = touch.clientY - offset.top;
             Logger.Log(
                 Logger.GetStackTrace(),
                 `F${this.fingerIds.get(touch.identifier)}=(${x}, ${y})`,


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
#287 

## Solution
Fixes #287 by making touch coordinates be relative to the viewport's absolute bounding rect rather than its own stated offset

## Test Plan and Compatibility
Uses a different class member to retrieve the video element's offset on screen, but the underlying logic is identical.

Tested by streaming a plain 3rd person project to an Android phone that previously reproduced the problem stated above.
