### PR TITLE
Properly inject new params into SDP to get stereo back on Chrome

### DIFF
--- a/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
+++ b/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
@@ -213,7 +213,7 @@ export class PeerConnectionController {
         );
 
         // set max bitrate to highest bitrate Opus supports
-        let audioSDP += 'maxaveragebitrate=510000;';
+        let audioSDP = 'maxaveragebitrate=510000;';
 
         if (useMic) {
             // set the max capture rate to 48khz (so we can send high quality audio from mic)

--- a/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
+++ b/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
@@ -207,16 +207,13 @@ export class PeerConnectionController {
      * @returns A modified Session Descriptor
      */
     mungeSDP(sdp: string, useMic: boolean) {
-        const mungedSDP = sdp;
-        mungedSDP.replace(
+        let mungedSDP = sdp.replace(
             /(a=fmtp:\d+ .*level-asymmetry-allowed=.*)\r\n/gm,
             '$1;x-google-start-bitrate=10000;x-google-max-bitrate=100000\r\n'
         );
 
-        let audioSDP = '';
-
         // set max bitrate to highest bitrate Opus supports
-        audioSDP += 'maxaveragebitrate=510000;';
+        let audioSDP += 'maxaveragebitrate=510000;';
 
         if (useMic) {
             // set the max capture rate to 48khz (so we can send high quality audio from mic)
@@ -232,7 +229,7 @@ export class PeerConnectionController {
         audioSDP += 'useinbandfec=1';
 
         // We use the line 'useinbandfec=1' (which Opus uses) to set our Opus specific audio parameters.
-        mungedSDP.replace('useinbandfec=1', audioSDP);
+        mungedSDP = mungedSDP.replace('useinbandfec=1', audioSDP);
 
         return mungedSDP;
     }


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Chrome suddenly stopped doing stereo output the other day...

## Solution
It turns out we were never actually modifying the SDP string because the return values for `replace` were being thrown away instead of being applied to `mungedSDP` which had itself been declared `const` for some reason anyway.

## Documentation
N/A

## Test Plan and Compatibility
I simply recompiled and checked out the infra in Chrome, noting that stereo has indeed returned. For good measure, I also checked the applied SDP configuration, noting that it now actually reflects the changes we wanted.
