### PR TITLE
Update LatencyTest handler to accept input data

### DIFF
--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -473,8 +473,10 @@ export class WebRtcPlayerController {
         this.streamMessageController.registerMessageHandler(
             MessageDirection.ToStreamer,
             'LatencyTest',
-            () =>
-                this.sendMessageController.sendMessageToStreamer('LatencyTest')
+            (data: Array<number | string>) =>
+                this.sendMessageController.sendMessageToStreamer(
+                    'LatencyTest', data
+                )
         );
         this.streamMessageController.registerMessageHandler(
             MessageDirection.ToStreamer,


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Addresses a bug introduced in https://github.com/EpicGames/PixelStreamingInfrastructure/pull/336 that results in the LatencyTest being unable to send.

## Solution
Update the registration of the handler to accept data which is of type `Array<number | string>` and pass this information to `sendMessageToStreamer`.
