### PR TITLE
Remove unit conversion for bitrate from URL. URL is already in kbps

### DIFF
--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -603,13 +603,13 @@ export class PixelStreaming {
             this.config.setNumericSetting(
                 NumericParameters.WebRTCMinBitrate,
                 (useUrlParams && urlParams.has(NumericParameters.WebRTCMinBitrate)) 
-                    ? Number.parseInt(urlParams.get(NumericParameters.WebRTCMinBitrate)) / 1000 /* bps to kbps */
+                    ? Number.parseInt(urlParams.get(NumericParameters.WebRTCMinBitrate))
                     : settings.WebRTCSettings.MinBitrate / 1000 /* bps to kbps */
             );
             this.config.setNumericSetting(
                 NumericParameters.WebRTCMaxBitrate,
                 (useUrlParams && urlParams.has(NumericParameters.WebRTCMaxBitrate)) 
-                    ? Number.parseInt(urlParams.get(NumericParameters.WebRTCMaxBitrate)) / 1000 /* bps to kbps */
+                    ? Number.parseInt(urlParams.get(NumericParameters.WebRTCMaxBitrate))
                     : settings.WebRTCSettings.MaxBitrate / 1000 /* bps to kbps */
                 
             );


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Setting the WebRTC bitrate in the URL would lead to the settings panel being incorrectly populated  on stream restart.

## Solution
The URL already specifies the bitrate in kbps so there is no need to do a unit conversion when populating settings panel.