### PR TITLE
Update SignallingWebServer platform scripts to support Mac

### DIFF
--- a/SignallingWebServer/platform_scripts/bash/Start_TURNServer.sh
+++ b/SignallingWebServer/platform_scripts/bash/Start_TURNServer.sh
@@ -25,7 +25,15 @@ echo ""
 
 # Hmm, plain text
 realm="PixelStreaming"
-process="turnserver"
+process=""
+if [ "$(uname)" == "Darwin" ]; then
+	process="${BASH_LOCATION}/coturn/bin/turnserver"
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+	process="turnserver"
+else
+	echo 'Incorrect host OS for use with Start_TURNServer.sh'
+	exit -1
+fi
 arguments="-c turnserver.conf --allowed-peer-ip=$localip -p ${turnport} -r $realm -X $publicip -E $localip -L $localip --no-cli --no-tls --no-dtls --pidfile /var/run/turnserver.pid -f -a -v -u ${turnusername}:${turnpassword}"
 
 # Add arguments passed to script to arguments for executable

--- a/SignallingWebServer/platform_scripts/bash/Start_TURNServer.sh
+++ b/SignallingWebServer/platform_scripts/bash/Start_TURNServer.sh
@@ -28,11 +28,8 @@ realm="PixelStreaming"
 process=""
 if [ "$(uname)" == "Darwin" ]; then
 	process="${BASH_LOCATION}/coturn/bin/turnserver"
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-	process="turnserver"
 else
-	echo 'Incorrect host OS for use with Start_TURNServer.sh'
-	exit -1
+	process="turnserver"
 fi
 arguments="-c turnserver.conf --allowed-peer-ip=$localip -p ${turnport} -r $realm -X $publicip -E $localip -L $localip --no-cli --no-tls --no-dtls --pidfile /var/run/turnserver.pid -f -a -v -u ${turnusername}:${turnpassword}"
 

--- a/SignallingWebServer/platform_scripts/bash/setup.sh
+++ b/SignallingWebServer/platform_scripts/bash/setup.sh
@@ -141,11 +141,8 @@ if [ "$(uname)" == "Darwin" ]; then
 		echo 'Incompatible architecture. Only x86_64 and ARM64 are supported'
 		exit -1
 	fi
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-	node_url="https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz"
 else
-	echo 'Incorrect OS for use with setup.sh'
-	exit -1
+	node_url="https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz"
 fi
 check_and_install "node" "$node_version" "$NODE_VERSION" "curl $node_url --output node.tar.xz
 															&& tar -xf node.tar.xz
@@ -179,7 +176,7 @@ if [ "$(uname)" == "Darwin" ]; then
 		tar -xf turnserver.zip -C "${BASH_LOCATION}/coturn"
 		rm turnserver.zip
 	fi
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+else
     #command #dep_name #get_version_string #version_min #install command
 	coturn_version=$(if command -v turnserver &> /dev/null; then echo 1; else echo 0; fi)
 	if [ $coturn_version -eq 0 ]; then

--- a/SignallingWebServer/platform_scripts/bash/setup.sh
+++ b/SignallingWebServer/platform_scripts/bash/setup.sh
@@ -167,9 +167,9 @@ if [ "$(uname)" == "Darwin" ]; then
 		echo 'CoTURN directory not found...beginning CoTURN download for Mac.'
 		coturn_url=""
 		if [[ $arch == x86_64* ]]; then
-			coturn_url="https://github.com/Belchy06/coturn/releases/download/v4.6.2-mac-x84_64/turnserver.zip"
+			coturn_url="https://github.com/EpicGames/PixelStreamingInfrastructure/releases/download/v4.6.2-coturn-mac-x86_64/turnserver.zip"
 		elif  [[ $arch == arm* ]]; then
-	    	coturn_url="https://github.com/Belchy06/coturn/releases/download/v4.6.2-mac-arm64/turnserver.zip"
+	    	coturn_url="https://github.com/EpicGames/PixelStreamingInfrastructure/releases/download/v4.6.2-coturn-mac-arm64/turnserver.zip"
 		fi
 		curl -L -o ./turnserver.zip "$coturn_url"
 		mkdir "${BASH_LOCATION}/coturn" 

--- a/SignallingWebServer/platform_scripts/bash/setup.sh
+++ b/SignallingWebServer/platform_scripts/bash/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
 BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+NODE_VERSION=v18.17.0
 
 pushd "${BASH_LOCATION}" > /dev/null
 
@@ -128,10 +129,28 @@ node_version=""
 if [[ -f "${BASH_LOCATION}/node/bin/node" ]]; then
 	node_version=$("${BASH_LOCATION}/node/bin/node" --version)
 fi
-check_and_install "node" "$node_version" "v18.17.0" "curl https://nodejs.org/dist/v18.17.0/node-v18.17.0-linux-x64.tar.gz --output node.tar.xz
-													&& tar -xf node.tar.xz
-													&& rm node.tar.xz
-													&& mv node-v*-linux-x64 \"${BASH_LOCATION}/node\""
+
+node_url=""
+if [ "$(uname)" == "Darwin" ]; then
+	arch=$(uname -m)
+	if [[ $arch == x86_64* ]]; then
+		node_url="https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-darwin-x64.tar.gz"
+	elif  [[ $arch == arm* ]]; then
+	    node_url="https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-darwin-arm64.tar.gz"
+	else
+		echo 'Incompatible architecture. Only x86_64 and ARM64 are supported'
+		exit -1
+	fi
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+	node_url="https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz"
+else
+	echo 'Incorrect OS for use with setup.sh'
+	exit -1
+fi
+check_and_install "node" "$node_version" "$NODE_VERSION" "curl $node_url --output node.tar.xz
+															&& tar -xf node.tar.xz
+															&& rm node.tar.xz
+															&& mv node-v*-*-* \"${BASH_LOCATION}/node\""
 
 PATH="${BASH_LOCATION}/node/bin:$PATH"
 "${BASH_LOCATION}/node/lib/node_modules/npm/bin/npm-cli.js" install
@@ -144,20 +163,38 @@ setup_frontend
 
 popd > /dev/null # BASH_SOURCE
 
-#command #dep_name #get_version_string #version_min #install command
-coturn_version=$(if command -v turnserver &> /dev/null; then echo 1; else echo 0; fi)
-if [ $coturn_version -eq 0 ]; then
-	if ! command -v apt-get &> /dev/null; then
-		echo "Setup for the scripts is designed for use with distros that use the apt-get package manager" \
-			 "if you are seeing this message you will have to update \"${BASH_LOCATION}/setup.sh\" with\n" \
-			 "a package manger and the equivalent packages for your distribution. Please follow the\n" \
-			 "instructions found at https://pkgs.org/search/?q=coturn to install Coturn for your specific distribution"
-		exit 1
+if [ "$(uname)" == "Darwin" ]; then
+	if [ -d "${BASH_LOCATION}/coturn" ]; then
+		echo 'CoTURN directory found...skipping install.'
 	else
-		if [ `id -u` -eq 0 ]; then
-			check_and_install "coturn" "$coturn_version" "1" "apt-get install -y coturn"
+		echo 'CoTURN directory not found...beginning CoTURN download for Mac.'
+		coturn_url=""
+		if [[ $arch == x86_64* ]]; then
+			coturn_url="https://github.com/Belchy06/coturn/releases/download/v4.6.2-mac-x84_64/turnserver.zip"
+		elif  [[ $arch == arm* ]]; then
+	    	coturn_url="https://github.com/Belchy06/coturn/releases/download/v4.6.2-mac-arm64/turnserver.zip"
+		fi
+		curl -L -o ./turnserver.zip "$coturn_url"
+		mkdir "${BASH_LOCATION}/coturn" 
+		tar -xf turnserver.zip -C "${BASH_LOCATION}/coturn"
+		rm turnserver.zip
+	fi
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    #command #dep_name #get_version_string #version_min #install command
+	coturn_version=$(if command -v turnserver &> /dev/null; then echo 1; else echo 0; fi)
+	if [ $coturn_version -eq 0 ]; then
+		if ! command -v apt-get &> /dev/null; then
+			echo "Setup for the scripts is designed for use with distros that use the apt-get package manager" \
+				 "if you are seeing this message you will have to update \"${BASH_LOCATION}/setup.sh\" with\n" \
+				 "a package manger and the equivalent packages for your distribution. Please follow the\n" \
+				 "instructions found at https://pkgs.org/search/?q=coturn to install Coturn for your specific distribution"
+			exit 1
 		else
-			check_and_install "coturn" "$coturn_version" "1" "sudo apt-get install -y coturn"
+			if [ `id -u` -eq 0 ]; then
+				check_and_install "coturn" "$coturn_version" "1" "apt-get install -y coturn"
+			else
+				check_and_install "coturn" "$coturn_version" "1" "sudo apt-get install -y coturn"
+			fi
 		fi
 	fi
 fi

--- a/SignallingWebServer/platform_scripts/cmd/setup_coturn.bat
+++ b/SignallingWebServer/platform_scripts/cmd/setup_coturn.bat
@@ -12,7 +12,7 @@ if exist coturn\ (
   echo CoTURN directory not found...beginning CoTURN download for Windows.
 
   @Rem Download nodejs and follow redirects.
-  curl -L -o ./turnserver.zip "https://github.com/mcottontensor/coturn/releases/download/v4.5.2-windows/turnserver.zip"
+  curl -L -o ./turnserver.zip "https://github.com/EpicGames/PixelStreamingInfrastructure/releases/download/v4.5.2-coturn-windows/turnserver.zip"
 
   @Rem Unarchive the .zip to a directory called "turnserver"
   mkdir coturn & tar -xf turnserver.zip -C coturn


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [X] Platform scripts
- [ ] SFU

## Problem statement:
Although PixelStreaming doesn't currently support Mac as a platform, this doesn't mean that the infrastructure can't be run on Mac (x86_64 / Arm64) devices.

## Solution
This PR modifies the bash platform scripts to first check for the OS and architecture before grabbing the appropriate Node binaries. 

Additionally, I've forked CoTurn and created binaries for each Mac architecture. This platform scripts now grab the correct binary for the machine's architecture as well.

## Documentation
No documentation updates as we didn't explicitly state that we didn't support Mac.
