### PR TITLE
[UI-library] Expose JSS InsertionPoint in PixelStreamingApplicationStyle.

### DIFF
--- a/Frontend/ui-library/src/Styles/PixelStreamingApplicationStyles.ts
+++ b/Frontend/ui-library/src/Styles/PixelStreamingApplicationStyles.ts
@@ -526,14 +526,16 @@ export class PixelStreamingApplicationStyle {
         customStyles?: Partial<Styles>;
         lightModePalette?: ColorPalette;
         darkModePalette?: ColorPalette;
+        jssInsertionPoint?: string | HTMLElement;
     }) {
-        const { customStyles, lightModePalette, darkModePalette } =
+        const { customStyles, lightModePalette, darkModePalette, jssInsertionPoint } =
             options ?? {};
         // One time setup with default plugins and settings.
         const jssOptions = {
             // JSS has many interesting plugins we may wish to turn on
             //plugins: [functions(), template(), global(), extend(), nested(), compose(), camelCase(), defaultUnit(options.defaultUnit), expand(), vendorPrefixer(), propsSort()]
-            plugins: [global(), camelCase()]
+            plugins: [global(), camelCase()],
+            insertionPoint: jssInsertionPoint
         };
 
         jss.setup(jssOptions);


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Frontend library
- [x] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
I'm embedding a Pixelstreaming component using the UI-Library in a single-page application made in Blazor.  

The ui-library styling is added to the `<head>` tag of the site, which makes the style persist for the life of the application.
Because of this, other unrelated parts of the application might be affected by this styling once the UI-Library has been used once.  
(This is caused by class names like `form-control` and `form-group` being shared by multiple frameworks.)

The JSS library being used under the hood already has functionality to specify where in the DOM the style gets added, the `InsertionPoint` parameter. This parameter fixes the issue as the styling can be injected into specific DOM nodes that can be removed when Pixelstreaming can be discarded.

You still need to be vigilant for class conflicts in styling when Pixelstreaming is active in the page, but this way we won't have to test the style of every other component of the app.



## Solution
This PR exposes the existing `InsertionPoint` parameter of JSS in the `PixelStreamingApplicationStyle` constructor.
I've named it `jssInsertionPoint` to clarify that it applies to the JSS options.


### Example usage
```diff
// example of specifying an insertionPoint for the styling

- const PixelStreamingApplicationStyles = new PixelStreamingApplicationStyle();
+ const PixelStreamingApplicationStyles = new PixelStreamingApplicationStyle({ 
+    jssInsertionPoint: document.getElementById("unreal-root")
+ });

  PixelStreamingApplicationStyles.applyStyleSheet();
```

The effect in a minimal HTML page:
![DOM](https://github.com/EpicGames/PixelStreamingInfrastructure/assets/11444698/f821773c-efb5-4b81-8c68-cab7356edcf8)


## Documentation
`InsertionPoint` is documented as a parameter of the [jss.setup function](https://cssinjs.org/jss-api?v=v10.10.0#setup-jss-instance) and in the JSS [setup instructions](https://cssinjs.org/setup/?v=v10.10.0#specify-the-dom-insertion-point).

> `insertionPoint` - string value of a DOM comment node which marks the start of sheets or a rendered DOM node. Sheets rendered by this Jss instance are inserted after this point sequentially.

I did not see in depth documentation of `PixelStreamingApplicationStyle`, thus I did not update any docs.

## Test Plan and Compatibility
#### Compatibility
This is a nullable parameter that was already implicitly null in the current implementation. Not using it should not break compatibility with any existing code.
In a personal repo I'm using this on the 5.2 branch, and as far as I can tell this can be backported to 5.2 and 5.3.

#### Testing
I did not add any unit tests as I felt that this would almost default to testing the JSS library itself.

Use cases that I tried manually:
- Supplying a HTML node using `document.getElementById()` works as expected.
- Suppling a string `'custom-insertion-point'` works with a `<!-- custom-insertion-point -->` comment inside the <head> element.  (see the 2nd docs link)

- Entering an invalid parameter (a Number using JS) will not throw any errors and give the default behavior.
- Entering an invalid string will show a clear warning in the browser console.
![error](https://github.com/EpicGames/PixelStreamingInfrastructure/assets/11444698/8ced45c1-d2c4-460f-8c81-522a65d49d01)

