### PR TITLE
[UI-library] Prevent errors on disabled setting or stats panel.

### DIFF
--- a/Frontend/ui-library/src/Application/Application.ts
+++ b/Frontend/ui-library/src/Application/Application.ts
@@ -487,7 +487,7 @@ export class Application {
      * Shows or hides the settings panel if clicked
      */
     settingsClicked() {
-        this.statsPanel.hide();
+        this.statsPanel?.hide();
         this.settingsPanel.toggleVisibility();
     }
 
@@ -495,7 +495,7 @@ export class Application {
      * Shows or hides the stats panel if clicked
      */
     statsClicked() {
-        this.settingsPanel.hide();
+        this.settingsPanel?.hide();
         this.statsPanel.toggleVisibility();
     }
 
@@ -583,7 +583,7 @@ export class Application {
             );
         }
         // disable starting a latency checks
-        this.statsPanel.onDisconnect();
+        this.statsPanel?.onDisconnect();
     }
 
     /**
@@ -630,7 +630,7 @@ export class Application {
         if (!this.stream.config.isFlagEnabled(Flags.AutoPlayVideo)) {
             this.showPlayOverlay();
         }
-        this.statsPanel.onVideoInitialized(this.stream);
+        this.statsPanel?.onVideoInitialized(this.stream);
     }
 
     /**
@@ -646,25 +646,25 @@ export class Application {
 
     onInitialSettings(settings: InitialSettings) {
         if (settings.PixelStreamingSettings) {
-            this.statsPanel.configure(settings.PixelStreamingSettings);
+            this.statsPanel?.configure(settings.PixelStreamingSettings);
         }
     }
 
     onStatsReceived(aggregatedStats: AggregatedStats) {
         // Grab all stats we can off the aggregated stats
-        this.statsPanel.handleStats(aggregatedStats);
+        this.statsPanel?.handleStats(aggregatedStats);
     }
 
     onLatencyTestResults(latencyTimings: LatencyTestResults) {
-        this.statsPanel.latencyTest.handleTestResult(latencyTimings);
+        this.statsPanel?.latencyTest.handleTestResult(latencyTimings);
     }
 
     onDataChannelLatencyTestResults(result: DataChannelLatencyTestResult) {
-        this.statsPanel.dataChannelLatencyTest.handleTestResult(result);
+        this.statsPanel?.dataChannelLatencyTest.handleTestResult(result);
     }
 
     onPlayerCount(playerCount: number) {
-        this.statsPanel.handlePlayerCount(playerCount);
+        this.statsPanel?.handlePlayerCount(playerCount);
     }
 
     handleStreamerListMessage(messageStreamingList: MessageStreamerList, autoSelectedStreamerId: string | null) {


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Frontend library
- [x] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
You can disable the settings and stats panel when using the ui-library.

```js
const application = new Application({
	stream,
	settingsPanelConfig: {
		isEnabled: false,
		visibilityButtonConfig: { creationMode: UIElementCreationMode.Disable }
	} ,
	statsPanelConfig: {
		isEnabled: false,
		visibilityButtonConfig: { creationMode: UIElementCreationMode.Disable }
	} 
});
```

However doing so might give you various errors because the `settingsPanel` or `statsPanel`  variable will be undefined.

- If you only disable the settings panel, the stats button will break.
The console shows an error as it tries `this.settingsPanel.hide();`.  

![onclick](https://github.com/EpicGames/PixelStreamingInfrastructure/assets/11444698/8e3e5aa8-101d-48a3-ac66-79a4c059938e)

- If you only disable the stats panel, you get the reverse with the settings button breaking.
- However the stats panel is also called repeatedly in other functions like
`onPlayerCount`, `onVideoInitialized` and `onStatsReceived`.
Although these don't seem to break anything visible to the user, they throw hundreds of console errors during a short stream.

![stats-error](https://github.com/EpicGames/PixelStreamingInfrastructure/assets/11444698/bd8ca528-b625-4875-9b59-d50bda80685c)



## Solution
Adding some `?` operators on usage of `this.settingsPanel` and `this.statsPanel` to avoid throwing errors.

## Documentation
N / A

## Test Plan and Compatibility
Some additional null checks shouldn't break any compatibility or features.

The stats and settings button don't break anymore in manual testing.

## Backporting
These errors show up starting with version 5.2 (which I use), but I'm making this pull request on master.
But because of code changes I'm not sure if a backport from master will fix all occurences in 5.2 and 5.3.

Please let me know If I need to make separate pull requests for other versions.