### PR TITLE
Fix errors when setting a null preferred codec

### DIFF
--- a/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
+++ b/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
@@ -180,7 +180,7 @@ export class PeerConnectionController {
             this.onVideoStats(this.aggregatedStats);
 
             // Update the preferred codec selection based on what was actually negotiated
-            if (this.updateCodecSelection) {
+            if (this.updateCodecSelection && !!this.aggregatedStats.inboundVideoStats.codecId) {
                 this.config.setOptionSettingValue(
                     OptionParameters.PreferredCodec,
                     this.aggregatedStats.codecs.get(
@@ -370,7 +370,7 @@ export class PeerConnectionController {
         if (RTCRtpReceiver.getCapabilities && this.preferredCodec != '') {
             for (const transceiver of this.peerConnection?.getTransceivers() ?? []) {
                 if (
-                    transceiver &&  
+                    transceiver &&
                     transceiver.receiver &&
                     transceiver.receiver.track &&
                     transceiver.receiver.track.kind === 'video' &&


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
If a user attempts to connect to a pixel stream but doesn't receive any video, the frontend will try to update the preferred codec dropdown with a null codec.

![image](https://github.com/EpicGames/PixelStreamingInfrastructure/assets/29305253/76250846-5c84-4fca-a2f1-c028c053b0e0)

## Solution
We'll simply check that the codec is not null before we try to set the dropdown value.