### PR TITLE
Update SFU platform scripts to support Mac

### DIFF
--- a/SFU/package.json
+++ b/SFU/package.json
@@ -5,20 +5,19 @@
   "private": true,
   "scripts": {
     "start-local": "run-script-os --",
-      "start-local:windows": ".\\platform_scripts\\cmd\\run.bat",
-      "start-local:default": "./platform_scripts/bash/run_local.sh",
+    "start-local:windows": ".\\platform_scripts\\cmd\\run.bat",
+    "start-local:default": "./platform_scripts/bash/run_local.sh",
     "start-cloud": "run-script-os --",
-      "start-cloud:windows": ".\\platform_scripts\\cmd\\run_cloud.bat",
-      "start-cloud:default": "./platform_scripts/bash/run_cloud.sh",
+    "start-cloud:windows": ".\\platform_scripts\\cmd\\run_cloud.bat",
+    "start-cloud:default": "./platform_scripts/bash/run_cloud.sh",
     "start": "run-script-os",
-      "start:windows": "platform_scripts\\cmd\\node\\node.exe sfu_server.js",
-      "start:default": "if [ `id -u` -eq 0 ]\nthen\n export process=\"./platform_scripts/bash/node/bin/node sfu_server.js\"\nelse\n export process=\"sudo ./platform_scripts/bash/node/bin/node sfu_server.js\"\nfi\n$process "
-      
+    "start:windows": "platform_scripts\\cmd\\node\\node.exe sfu_server.js",
+    "start:default": "if [ `id -u` -eq 0 ]\nthen\n export process=\"./platform_scripts/bash/node/bin/node sfu_server.js\"\nelse\n export process=\"sudo ./platform_scripts/bash/node/bin/node sfu_server.js\"\nfi\n$process "
   },
   "dependencies": {
     "mediasoup-sdp-bridge": "file:mediasoup-sdp-bridge",
     "ws": "^7.1.2",
-    "mediasoup_prebuilt": "^3.8.4",
+    "mediasoup": "^3.8.4",
     "run-script-os": "^1.1.6"
   }
 }

--- a/SFU/platform_scripts/bash/docker-build.sh
+++ b/SFU/platform_scripts/bash/docker-build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
+BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-# Build docker image for the Selective Forwarding Unit (SFU)
+pushd "${BASH_LOCATION}" > /dev/null
 
 # When run from SFU/platform_scripts/bash, this uses the SFU directory
 # as the build context so the SFU files can be successfully copied into the container image
-docker build -t 'mediasoup_sfu:latest' -f ./Dockerfile ../..
-
+docker build -t 'mediasoup_sfu:latest' -f "${BASH_LOCATION}/Dockerfile" "${BASH_LOCATION}/../.."

--- a/SFU/platform_scripts/bash/setup.sh
+++ b/SFU/platform_scripts/bash/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
 BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+NODE_VERSION=v18.17.0
 
 pushd "${BASH_LOCATION}" > /dev/null
 
@@ -99,10 +100,25 @@ node_version=""
 if [[ -f "${BASH_LOCATION}/node/bin/node" ]]; then
 	node_version=$("${BASH_LOCATION}/node/bin/node" --version)
 fi
-check_and_install "node" "$node_version" "v18.17.0" "curl https://nodejs.org/dist/v18.17.0/node-v18.17.0-linux-x64.tar.gz --output node.tar.xz 
-													&& tar -xf node.tar.xz 
-													&& rm node.tar.xz 
-													&& mv node-v*-linux-x64 \"${BASH_LOCATION}/node\""
+
+node_url=""
+if [ "$(uname)" == "Darwin" ]; then
+	arch=$(uname -m)
+	if [[ $arch == x86_64* ]]; then
+		node_url="https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-darwin-x64.tar.gz"
+	elif  [[ $arch == arm* ]]; then
+	    node_url="https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-darwin-arm64.tar.gz"
+	else
+		echo 'Incompatible architecture. Only x86_64 and ARM64 are supported'
+		exit -1
+	fi
+else
+	node_url="https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x64.tar.gz"
+fi
+check_and_install "node" "$node_version" "$NODE_VERSION" "curl $node_url --output node.tar.xz
+															&& tar -xf node.tar.xz
+															&& rm node.tar.xz
+															&& mv node-v*-*-* \"${BASH_LOCATION}/node\""
 
 PATH="${BASH_LOCATION}/node/bin:$PATH"
 "${BASH_LOCATION}/node/lib/node_modules/npm/bin/npm-cli.js" install

--- a/SFU/sfu_server.js
+++ b/SFU/sfu_server.js
@@ -44,7 +44,7 @@ async function onStreamerOffer(sdp) {
 }
 
 function getNextStreamerSCTPId() {
-  return streamer.transport._getNextSctpStreamId();
+  return streamer.transport.getNextSctpStreamId();
 }
 
 function onStreamerDisconnected() {
@@ -133,9 +133,6 @@ async function setupPeerDataChannels(peerId) {
   // streamer data consumer (consumes peer data)
   peer.streamerDataConsumer = await streamer.transport.consumeData({ dataProducerId: peer.peerDataProducer.id });
 
-  streamer.transport._sctpStreamIds[nextStreamerSCTPStreamId] = 1;
-  streamer.transport._sctpStreamIds[nextPeerSCTPStreamId] = 1;
-
   const peerSignal = {
     type: 'peerDataChannels',
     playerId: peerId,
@@ -196,13 +193,6 @@ function onPeerDisconnected(peerId) {
       peer.peerDataProducer.close();
     }
     if (peer.streamerDataConsumer) {
-      // Set the streamer sctp id we generated back to zero indicating it can be reused.
-      if (streamer && streamer.transport && streamer.transport._sctpStreamIds) {
-        const allocatedStreamId = peer.streamerDataProducer.sctpStreamParameters.streamId;
-        const allocatedPeerStreamId = peer.peerDataProducer.sctpStreamParameters.streamId;
-        streamer.transport._sctpStreamIds[allocatedStreamId] = 0;
-        streamer.transport._sctpStreamIds[allocatedPeerStreamId] = 0;
-      }
       peer.streamerDataConsumer.close();
       peer.streamerDataProducer.close();
     }


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [X] Platform scripts
- [X] SFU

## Problem statement:
SFU doesn't currently support Mac due to using prebuilt binaries of Mediasoup. Additionally, the platform scripts for the SFU don't download Mac specific Node binaries.

## Solution
To address the SFU no supporting Mac, we can just use the normal npm package which works fine.

To fix the setup scripts, I've copied the same logic that's currently in the SignallingWebServer platform scripts.

## Test Plan and Compatibility
Tested SFU on Mac on both the host and in a container.