### PR TITLE
[Frontend] Fix faketouch capturing touches on UI.

### DIFF
--- a/Frontend/library/src/Inputs/FakeTouchController.ts
+++ b/Frontend/library/src/Inputs/FakeTouchController.ts
@@ -72,7 +72,7 @@ export class FakeTouchController implements ITouchController {
      * @param touch - the activating touch event
      */
     onTouchStart(touch: TouchEvent): void {
-        if (!this.videoElementProvider.isVideoReady()) {
+        if (!this.videoElementProvider.isVideoReady() || touch.target !== this.videoElementProvider.getVideoElement()) {
             return;
         }
         if (this.fakeTouchFinger == null) {
@@ -108,7 +108,7 @@ export class FakeTouchController implements ITouchController {
      * @param touchEvent - the activating touch event
      */
     onTouchEnd(touchEvent: TouchEvent): void {
-        if (!this.videoElementProvider.isVideoReady()) {
+        if (!this.videoElementProvider.isVideoReady() || this.fakeTouchFinger == null) {
             return;
         }
         const videoElementParent =
@@ -144,7 +144,7 @@ export class FakeTouchController implements ITouchController {
      * @param touchEvent - the activating touch event
      */
     onTouchMove(touchEvent: TouchEvent): void {
-        if (!this.videoElementProvider.isVideoReady()) {
+        if (!this.videoElementProvider.isVideoReady() || this.fakeTouchFinger == null) {
             return;
         }
         const toStreamerHandlers =


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
When you enable the setting `FakeMouseWithTouches`, touches on the UI buttons will no longer work.

```ts
config.setFlagEnabled(Flags.FakeMouseWithTouches, true);
```

- On mobile devices the stats/settings/fullscreen buttons in the example won't trigger at all. 
(Tested on iOS 17 Safari & Chrome and Android 13 Chrome & Firefox.)
- On desktop in the Chrome of Android devtools with touch emulation, the buttons require multiple click to trigger.

This is applicable from version 5.2 up to 5.4 and the master branch.

## Screen captures

On Android 13 on the latest Chrome browser:

| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/EpicGames/PixelStreamingInfrastructure/assets/11444698/1842f424-c0c1-4e8a-b094-4a5fa6c021fc" style="max-width:50%;" />  | <video src="https://github.com/EpicGames/PixelStreamingInfrastructure/assets/11444698/20b1ea30-9c95-4faa-9ac0-6ae68837c074" style="max-width:50%;"/>  |





## Solution
The issue is caused by `touch.preventDefault()` in the FakeTouchController script.

- In `OnTouchStart` I check whether the touch is actually on the video element.

- In `OnTouchMove` and `OnTouchEnd` I added a null check because the existing code can run into an undefined `this.fakeTouchFinger.id`.
This also avoids the `preventDefault` call when it is not needed.


The only drawback of this 'fix' is that the focus state of the buttons will not blur when clicking the video, as you can see at the end of the 'after' video.
This could be resolved by entirely removing `touch.prevenDefault()` from the `OnTouchEnd` function, but I'm not sure if this might have any unintended side effects.

## Documentation
N / A

## Test Plan and Compatibility
This could theoretically break someone's existing project if they place HTML elements on top of the video element, maybe for some kind of gradient or vignette effect.  
However disabling pointer events on those elements should solve any issues.
