### PR TITLE
Bitrate negotiation on stream startup

### DIFF
--- a/Frontend/library/src/Config/SettingNumber.ts
+++ b/Frontend/library/src/Config/SettingNumber.ts
@@ -37,7 +37,7 @@ export class SettingNumber<
         if (!useUrlParams || !urlParams.has(this.id)) {
             this.number = defaultNumber;
         } else {
-            const parsedValue = Number.parseInt(urlParams.get(this.id));
+            const parsedValue = Number.parseFloat(urlParams.get(this.id));
             this.number = Number.isNaN(parsedValue)
                 ? defaultNumber
                 : parsedValue;

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -571,7 +571,7 @@ export class PixelStreaming {
                 NumericParameters.MinQP,
                 // If a setting is set in the URL, make sure we respect that value as opposed to what the application sends us
                 (useUrlParams && urlParams.has(NumericParameters.MinQP)) 
-                    ? Number.parseInt(urlParams.get(NumericParameters.MinQP)) 
+                    ? Number.parseFloat(urlParams.get(NumericParameters.MinQP)) 
                     : settings.EncoderSettings.MinQP
             );
 
@@ -579,7 +579,7 @@ export class PixelStreaming {
             this.config.setNumericSetting(
                 NumericParameters.MaxQP,
                 (useUrlParams && urlParams.has(NumericParameters.MaxQP)) 
-                    ? Number.parseInt(urlParams.get(NumericParameters.MaxQP)) 
+                    ? Number.parseFloat(urlParams.get(NumericParameters.MaxQP)) 
                     : settings.EncoderSettings.MaxQP
             );
         }
@@ -587,20 +587,20 @@ export class PixelStreaming {
             this.config.setNumericSetting(
                 NumericParameters.WebRTCMinBitrate,
                 (useUrlParams && urlParams.has(NumericParameters.WebRTCMinBitrate)) 
-                    ? Number.parseInt(urlParams.get(NumericParameters.WebRTCMinBitrate))
-                    : settings.WebRTCSettings.MinBitrate / 1000 /* bps to kbps */
+                    ? Number.parseFloat(urlParams.get(NumericParameters.WebRTCMinBitrate))
+                    : (settings.WebRTCSettings.MinBitrate / 1000) /* bps to kbps */
             );
             this.config.setNumericSetting(
                 NumericParameters.WebRTCMaxBitrate,
                 (useUrlParams && urlParams.has(NumericParameters.WebRTCMaxBitrate)) 
-                    ? Number.parseInt(urlParams.get(NumericParameters.WebRTCMaxBitrate))
-                    : settings.WebRTCSettings.MaxBitrate / 1000 /* bps to kbps */
+                    ? Number.parseFloat(urlParams.get(NumericParameters.WebRTCMaxBitrate))
+                    : (settings.WebRTCSettings.MaxBitrate / 1000) /* bps to kbps */
                 
             );
             this.config.setNumericSetting(
                 NumericParameters.WebRTCFPS,
                 (useUrlParams && urlParams.has(NumericParameters.WebRTCFPS)) 
-                    ? Number.parseInt(urlParams.get(NumericParameters.WebRTCFPS))
+                    ? Number.parseFloat(urlParams.get(NumericParameters.WebRTCFPS))
                     : settings.WebRTCSettings.FPS
             );
         }

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1551,7 +1551,11 @@ export class WebRtcPlayerController {
             'Sending the offer to the Server',
             6
         );
-        this.webSocketController.sendWebRtcOffer(offer);
+        
+        const minBitrate = 1000 * this.config.getNumericSettingValue(NumericParameters.WebRTCMinBitrate);
+        const maxBitrate = 1000 * this.config.getNumericSettingValue(NumericParameters.WebRTCMaxBitrate);
+
+        this.webSocketController.sendWebRtcOffer(offer, minBitrate, maxBitrate);
     }
 
     /**
@@ -1564,7 +1568,11 @@ export class WebRtcPlayerController {
             'Sending the answer to the Server',
             6
         );
-        this.webSocketController.sendWebRtcAnswer(answer);
+
+        const minBitrate = 1000 * this.config.getNumericSettingValue(NumericParameters.WebRTCMinBitrate);
+        const maxBitrate = 1000 * this.config.getNumericSettingValue(NumericParameters.WebRTCMaxBitrate);
+
+        this.webSocketController.sendWebRtcAnswer(answer, minBitrate, maxBitrate);
 
         if (this.isUsingSFU) {
             this.webSocketController.sendWebRtcDatachannelRequest();

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1,6 +1,6 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
-import { WebSocketController } from '../WebSockets/WebSocketController';
+import { WebSocketController, ExtraOfferParameters, ExtraAnswerParameters } from '../WebSockets/WebSocketController';
 import { StreamController } from '../VideoPlayer/StreamController';
 import {
     MessageAnswer,
@@ -1551,11 +1551,13 @@ export class WebRtcPlayerController {
             'Sending the offer to the Server',
             6
         );
-        
-        const minBitrate = 1000 * this.config.getNumericSettingValue(NumericParameters.WebRTCMinBitrate);
-        const maxBitrate = 1000 * this.config.getNumericSettingValue(NumericParameters.WebRTCMaxBitrate);
 
-        this.webSocketController.sendWebRtcOffer(offer, minBitrate, maxBitrate);
+        const extraParams: ExtraOfferParameters = {
+            minBitrateBps: 1000 * this.config.getNumericSettingValue(NumericParameters.WebRTCMinBitrate),
+            maxBitrateBps: 1000 * this.config.getNumericSettingValue(NumericParameters.WebRTCMaxBitrate)
+        };
+
+        this.webSocketController.sendWebRtcOffer(offer, extraParams);
     }
 
     /**
@@ -1569,10 +1571,12 @@ export class WebRtcPlayerController {
             6
         );
 
-        const minBitrate = 1000 * this.config.getNumericSettingValue(NumericParameters.WebRTCMinBitrate);
-        const maxBitrate = 1000 * this.config.getNumericSettingValue(NumericParameters.WebRTCMaxBitrate);
+        const extraParams: ExtraAnswerParameters = {
+            minBitrateBps: 1000 * this.config.getNumericSettingValue(NumericParameters.WebRTCMinBitrate),
+            maxBitrateBps: 1000 * this.config.getNumericSettingValue(NumericParameters.WebRTCMaxBitrate)
+        };
 
-        this.webSocketController.sendWebRtcAnswer(answer, minBitrate, maxBitrate);
+        this.webSocketController.sendWebRtcAnswer(answer, extraParams);
 
         if (this.isUsingSFU) {
             this.webSocketController.sendWebRtcDatachannelRequest();

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1,6 +1,7 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
-import { WebSocketController, ExtraOfferParameters, ExtraAnswerParameters } from '../WebSockets/WebSocketController';
+import { WebSocketController } from '../WebSockets/WebSocketController';
+import { ExtraOfferParameters, ExtraAnswerParameters } from '../WebSockets/MessageSend';
 import { StreamController } from '../VideoPlayer/StreamController';
 import {
     MessageAnswer,

--- a/Frontend/library/src/WebSockets/MessageSend.ts
+++ b/Frontend/library/src/WebSockets/MessageSend.ts
@@ -27,6 +27,11 @@ export class MessageSend implements Send {
     /**
      * A filter for controlling what parameters to actually send.
      * Good for excluding default values or hidden internals.
+     * Example for including everything but zero bitrate fields...
+     * sendFilter(key: string, value: any) {
+     *   if ((key == "minBitrate" || key == "maxBitrate") && value <= 0) return undefined;
+     *   return value;
+     * }
      * Return undefined to exclude the property completely.
      */
     sendFilter(key: string, value: any) {

--- a/Frontend/library/src/WebSockets/MessageSend.ts
+++ b/Frontend/library/src/WebSockets/MessageSend.ts
@@ -149,7 +149,7 @@ export class MessageWebRTCAnswer extends MessageSend {
     /**
      * @param answer - Generated Web RTC Offer
      */
-    constructor(answer: RTCSessionDescriptionInit, extraParams: ExtraOfferParameters) {
+    constructor(answer: RTCSessionDescriptionInit, extraParams: ExtraAnswerParameters) {
         super();
         this.type = MessageSendTypes.ANSWER;
         this.minBitrate = 0;

--- a/Frontend/library/src/WebSockets/MessageSend.ts
+++ b/Frontend/library/src/WebSockets/MessageSend.ts
@@ -25,16 +25,25 @@ export class MessageSend implements Send {
     peerConnectionOptions: object;
 
     /**
+     * A filter for controlling what parameters to actually send.
+     * Good for excluding default values or hidden internals.
+     * Return undefined to exclude the property completely.
+     */
+    sendFilter(key: string, value: any) {
+        return value;
+    }
+
+    /**
      * Turns the wrapper into a JSON String
      * @returns - JSON String of the Message to send
      */
     payload() {
         Logger.Log(
             Logger.GetStackTrace(),
-            'Sending => \n' + JSON.stringify(this, undefined, 4),
+            'Sending => \n' + JSON.stringify(this, this.sendFilter, 4),
             6
         );
-        return JSON.stringify(this);
+        return JSON.stringify(this, this.sendFilter);
     }
 }
 
@@ -88,18 +97,29 @@ export class MessagePong extends MessageSend {
  */
 export class MessageWebRTCOffer extends MessageSend {
     sdp: string;
+    minBitrate: number;
+    maxBitrate: number;
 
     /**
      * @param offer - Generated Web RTC Offer
      */
-    constructor(offer?: RTCSessionDescriptionInit) {
+    constructor(offer: RTCSessionDescriptionInit, minBitrate: number, maxBitrate: number) {
         super();
         this.type = MessageSendTypes.OFFER;
+        this.minBitrate = 0;
+        this.maxBitrate = 0;
 
         if (offer) {
             this.type = offer.type as MessageSendTypes;
             this.sdp = offer.sdp;
+            this.minBitrate = minBitrate;
+            this.maxBitrate = maxBitrate;
         }
+    }
+
+    sendFilter(key: string, value: any) {
+        if ((key == "minBitrate" || key == "maxBitrate") && value <= 0) return undefined;
+        return value;
     }
 }
 
@@ -108,18 +128,29 @@ export class MessageWebRTCOffer extends MessageSend {
  */
 export class MessageWebRTCAnswer extends MessageSend {
     sdp: string;
+    minBitrate: number;
+    maxBitrate: number;
 
     /**
      * @param answer - Generated Web RTC Offer
      */
-    constructor(answer?: RTCSessionDescriptionInit) {
+    constructor(answer: RTCSessionDescriptionInit, minBitrate: number, maxBitrate: number) {
         super();
         this.type = MessageSendTypes.ANSWER;
+        this.minBitrate = 0;
+        this.maxBitrate = 0;
 
         if (answer) {
             this.type = answer.type as MessageSendTypes;
             this.sdp = answer.sdp;
+            this.minBitrate = minBitrate;
+            this.maxBitrate = maxBitrate;
         }
+    }
+
+    sendFilter(key: string, value: any) {
+        if ((key == "minBitrate" || key == "maxBitrate") && value <= 0) return undefined;
+        return value;
     }
 }
 

--- a/Frontend/library/src/WebSockets/MessageSend.ts
+++ b/Frontend/library/src/WebSockets/MessageSend.ts
@@ -97,6 +97,11 @@ export class MessagePong extends MessageSend {
     }
 }
 
+export type ExtraOfferParameters = {
+    minBitrateBps: number;
+    maxBitrateBps: number;
+}
+
 /**
  *  Web RTC Offer message wrapper
  */
@@ -108,7 +113,7 @@ export class MessageWebRTCOffer extends MessageSend {
     /**
      * @param offer - Generated Web RTC Offer
      */
-    constructor(offer: RTCSessionDescriptionInit, minBitrate: number, maxBitrate: number) {
+    constructor(offer: RTCSessionDescriptionInit, extraParams: ExtraOfferParameters) {
         super();
         this.type = MessageSendTypes.OFFER;
         this.minBitrate = 0;
@@ -117,8 +122,8 @@ export class MessageWebRTCOffer extends MessageSend {
         if (offer) {
             this.type = offer.type as MessageSendTypes;
             this.sdp = offer.sdp;
-            this.minBitrate = minBitrate;
-            this.maxBitrate = maxBitrate;
+            this.minBitrate = extraParams.minBitrateBps;
+            this.maxBitrate = extraParams.maxBitrateBps;
         }
     }
 
@@ -126,6 +131,11 @@ export class MessageWebRTCOffer extends MessageSend {
         if ((key == "minBitrate" || key == "maxBitrate") && value <= 0) return undefined;
         return value;
     }
+}
+
+export type ExtraAnswerParameters = {
+    minBitrateBps: number;
+    maxBitrateBps: number;
 }
 
 /**
@@ -139,7 +149,7 @@ export class MessageWebRTCAnswer extends MessageSend {
     /**
      * @param answer - Generated Web RTC Offer
      */
-    constructor(answer: RTCSessionDescriptionInit, minBitrate: number, maxBitrate: number) {
+    constructor(answer: RTCSessionDescriptionInit, extraParams: ExtraOfferParameters) {
         super();
         this.type = MessageSendTypes.ANSWER;
         this.minBitrate = 0;
@@ -148,8 +158,8 @@ export class MessageWebRTCAnswer extends MessageSend {
         if (answer) {
             this.type = answer.type as MessageSendTypes;
             this.sdp = answer.sdp;
-            this.minBitrate = minBitrate;
-            this.maxBitrate = maxBitrate;
+            this.minBitrate = extraParams.minBitrateBps;
+            this.maxBitrate = extraParams.maxBitrateBps;
         }
     }
 

--- a/Frontend/library/src/WebSockets/WebSocketController.ts
+++ b/Frontend/library/src/WebSockets/WebSocketController.ts
@@ -12,16 +12,6 @@ declare global {
     }
 }
 
-export type ExtraOfferParameters = {
-    minBitrateBps: number;
-    maxBitrateBps: number;
-}
-
-export type ExtraAnswerParameters = {
-    minBitrateBps: number;
-    maxBitrateBps: number;
-}
-
 /**
  * The controller for the WebSocket and all associated methods
  */
@@ -169,13 +159,13 @@ export class WebSocketController {
         this.webSocket.send(payload.payload());
     }
 
-    sendWebRtcOffer(offer: RTCSessionDescriptionInit, extraParams: ExtraOfferParameters) {
-        const payload = new MessageSend.MessageWebRTCOffer(offer, extraParams.minBitrateBps, extraParams.maxBitrateBps);
+    sendWebRtcOffer(offer: RTCSessionDescriptionInit, extraParams: MessageSend.ExtraOfferParameters) {
+        const payload = new MessageSend.MessageWebRTCOffer(offer, extraParams);
         this.webSocket.send(payload.payload());
     }
 
-    sendWebRtcAnswer(answer: RTCSessionDescriptionInit, extraParams: ExtraAnswerParameters) {
-        const payload = new MessageSend.MessageWebRTCAnswer(answer, extraParams.minBitrateBps, extraParams.maxBitrateBps);
+    sendWebRtcAnswer(answer: RTCSessionDescriptionInit, extraParams: MessageSend.ExtraAnswerParameters) {
+        const payload = new MessageSend.MessageWebRTCAnswer(answer, extraParams);
         this.webSocket.send(payload.payload());
     }
 

--- a/Frontend/library/src/WebSockets/WebSocketController.ts
+++ b/Frontend/library/src/WebSockets/WebSocketController.ts
@@ -12,6 +12,16 @@ declare global {
     }
 }
 
+export type ExtraOfferParameters = {
+    minBitrateBps: number;
+    maxBitrateBps: number;
+}
+
+export type ExtraAnswerParameters = {
+    minBitrateBps: number;
+    maxBitrateBps: number;
+}
+
 /**
  * The controller for the WebSocket and all associated methods
  */
@@ -159,13 +169,13 @@ export class WebSocketController {
         this.webSocket.send(payload.payload());
     }
 
-    sendWebRtcOffer(offer: RTCSessionDescriptionInit, minBitrate: number, maxBitrate: number) {
-        const payload = new MessageSend.MessageWebRTCOffer(offer, minBitrate, maxBitrate);
+    sendWebRtcOffer(offer: RTCSessionDescriptionInit, extraParams: ExtraOfferParameters) {
+        const payload = new MessageSend.MessageWebRTCOffer(offer, extraParams.minBitrateBps, extraParams.maxBitrateBps);
         this.webSocket.send(payload.payload());
     }
 
-    sendWebRtcAnswer(answer: RTCSessionDescriptionInit, minBitrate: number, maxBitrate: number) {
-        const payload = new MessageSend.MessageWebRTCAnswer(answer, minBitrate, maxBitrate);
+    sendWebRtcAnswer(answer: RTCSessionDescriptionInit, extraParams: ExtraAnswerParameters) {
+        const payload = new MessageSend.MessageWebRTCAnswer(answer, extraParams.minBitrateBps, extraParams.maxBitrateBps);
         this.webSocket.send(payload.payload());
     }
 

--- a/Frontend/library/src/WebSockets/WebSocketController.ts
+++ b/Frontend/library/src/WebSockets/WebSocketController.ts
@@ -159,13 +159,13 @@ export class WebSocketController {
         this.webSocket.send(payload.payload());
     }
 
-    sendWebRtcOffer(offer: RTCSessionDescriptionInit) {
-        const payload = new MessageSend.MessageWebRTCOffer(offer);
+    sendWebRtcOffer(offer: RTCSessionDescriptionInit, minBitrate: number, maxBitrate: number) {
+        const payload = new MessageSend.MessageWebRTCOffer(offer, minBitrate, maxBitrate);
         this.webSocket.send(payload.payload());
     }
 
-    sendWebRtcAnswer(answer: RTCSessionDescriptionInit) {
-        const payload = new MessageSend.MessageWebRTCAnswer(answer);
+    sendWebRtcAnswer(answer: RTCSessionDescriptionInit, minBitrate: number, maxBitrate: number) {
+        const payload = new MessageSend.MessageWebRTCAnswer(answer, minBitrate, maxBitrate);
         this.webSocket.send(payload.payload());
     }
 

--- a/Frontend/ui-library/src/Config/SettingUINumber.ts
+++ b/Frontend/ui-library/src/Config/SettingUINumber.ts
@@ -77,7 +77,7 @@ export class SettingUINumber<
             this.spinner.onchange = (event: Event) => {
                 const inputElem = event.target as HTMLInputElement;
 
-                const parsedValue = Number.parseInt(inputElem.value);
+                const parsedValue = Number.parseFloat(inputElem.value);
 
                 if (Number.isNaN(parsedValue)) {
                     Logger.Warning(


### PR DESCRIPTION
- Added min/max bitrate requests for offer/answer messages
- Fixing bitrate values in the frontend units and parsing.

## Relevant components:
- [ ] Signalling server
- [x] Frontend library
- [x] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Setting the bitrate values before starting the stream did not work.

## Solution
Added min/max bitrate values to the answer signalling message so the streamer can extract them and set them when needed.

## Documentation

## Test Plan and Compatibility
Will probably need a QA pass.