### PR TITLE
chore: remove auto-assigned prop

### DIFF
--- a/Frontend/ui-library/webpack.common.js
+++ b/Frontend/ui-library/webpack.common.js
@@ -32,7 +32,6 @@ module.exports = {
         })
     ],
     output: {
-        path: path.resolve(__dirname, 'dist'),
         globalObject: 'this'
     }
 };


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Frontend library
- [x] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Removes prop that is automatically assigned in webpack

## Solution
N/A

## Documentation
N/A

## Test Plan and Compatibility
N/A

Or better yet, link to the unit tests that accompany this PR.
