### PR TITLE
Fix formatting in bug_report template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,10 +7,10 @@ assignees: ''
 
 ---
 
-**UE Version: **
+**UE Version:**
 E.g. UE 5.1.1
 
-**Frontend Version: **
+**Frontend Version:**
 E.g. UE5.3-0.3.0
 
 **Problem component**


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
The issue template for bugs has a small formatting error for the top 2 headings, which don't become bold.
You can see this replicated in most recent issues in the issues tab.

![bug_template](https://github.com/EpicGames/PixelStreamingInfrastructure/assets/11444698/ad5d8e8c-afd2-4997-8335-4c8105826528)


## Solution
Remove a space to fix the formatting.

![bug_template2](https://github.com/EpicGames/PixelStreamingInfrastructure/assets/11444698/36db9f65-0ae2-43a8-919a-93517d0887f1)
