### PR TITLE
Fixing handling of StreamerId in the initial config settings.

### DIFF
--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -742,7 +742,13 @@ export class Config {
                 `Cannot set text setting called ${id} - it does not exist in the Config.enumParameters map.`
             );
         } else {
-            this.optionParameters.get(id).selected = settingValue;
+            const optionSetting = this.optionParameters.get(id);
+            const existingOptions = optionSetting.options;
+            if (!existingOptions.includes(settingValue)) {
+                existingOptions.push(settingValue);
+                optionSetting.options = existingOptions;
+            }
+            optionSetting.selected = settingValue;
         }
     }
 

--- a/Frontend/library/src/Config/SettingOption.ts
+++ b/Frontend/library/src/Config/SettingOption.ts
@@ -24,7 +24,7 @@ export class SettingOption<
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		defaultOnChangeListener: (changedValue: unknown, setting: SettingBase) => void = () => { /* Do nothing, to be overridden. */ }
     ) {
-        super(id, label, description, [defaultTextValue, defaultTextValue], defaultOnChangeListener);
+        super(id, label, description, [defaultTextValue], defaultOnChangeListener);
 
         this.options = options;
         const urlParams = new URLSearchParams(window.location.search);

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -566,6 +566,10 @@ export class PixelStreaming {
 
         const useUrlParams = this.config.useUrlParams;
         const urlParams = new URLSearchParams(window.location.search);
+        Logger.Info(
+            Logger.GetStackTrace(),
+            `using URL parameters ${useUrlParams}`
+        );
         if (settings.EncoderSettings) {
             this.config.setNumericSetting(
                 NumericParameters.MinQP,

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1322,6 +1322,10 @@ export class WebRtcPlayerController {
             6
         );
 
+        // get the current selected streamer id option
+        var streamerIDOption = this.config.getSettingOption(OptionParameters.StreamerId);
+        const currentSelectedStreamerID = streamerIDOption.selected;
+
         // add the streamers to the UI
         const settingOptions = [...messageStreamerList.ids]; // copy the original messageStreamerList.ids
         settingOptions.unshift(''); // add an empty option at the top
@@ -1330,15 +1334,16 @@ export class WebRtcPlayerController {
             settingOptions
         );
 
-        let wantedStreamerId: string = null;
+        let wantedStreamerId: string = currentSelectedStreamerID; // default to previously selected
         let autoSelectedStreamerId: string  = null;
         const waitForStreamer = this.config.isFlagEnabled(Flags.WaitForStreamer);
         const reconnectLimit = this.config.getNumericSettingValue(NumericParameters.MaxReconnectAttempts);
         const reconnectDelay = this.config.getNumericSettingValue(NumericParameters.StreamerAutoJoinInterval);
 
         // first we figure out a wanted streamer id through various means
+        const useUrlParams = this.config.useUrlParams;
         const urlParams = new URLSearchParams(window.location.search);
-        if (urlParams.has(OptionParameters.StreamerId)) {
+        if (useUrlParams && urlParams.has(OptionParameters.StreamerId)) {
             // if we've set the streamer id on the url we only want that streamer id
             wantedStreamerId = urlParams.get(OptionParameters.StreamerId);
         } else if (this.subscribedStream) {

--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1322,9 +1322,15 @@ export class WebRtcPlayerController {
             6
         );
 
+        let wantedStreamerId: string = null;
+
         // get the current selected streamer id option
         var streamerIDOption = this.config.getSettingOption(OptionParameters.StreamerId);
-        const currentSelectedStreamerID = streamerIDOption.selected;
+        const existingSelection = streamerIDOption.selected.toString().trim();
+        if (!!existingSelection) {
+            // default to selected option if it exists
+            wantedStreamerId = streamerIDOption.selected;
+        }
 
         // add the streamers to the UI
         const settingOptions = [...messageStreamerList.ids]; // copy the original messageStreamerList.ids
@@ -1334,7 +1340,6 @@ export class WebRtcPlayerController {
             settingOptions
         );
 
-        let wantedStreamerId: string = currentSelectedStreamerID; // default to previously selected
         let autoSelectedStreamerId: string  = null;
         const waitForStreamer = this.config.isFlagEnabled(Flags.WaitForStreamer);
         const reconnectLimit = this.config.getNumericSettingValue(NumericParameters.MaxReconnectAttempts);


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
As described in #436 setting the StreamerId in the initial config does not work. This is because if we try to set an option selection that isn't already in the list the selection is ignored, and additionally when we get the streamer list, this option list is thrown out and reset with the streamer ids.

## Solution
- The setOptionSettingValue now adds the selected value if it doesn't already exist in the list. Without this the selection does not happen.
- handleStreamerListMessage now checks the existing selection and uses it as the default wantedStreamerId. It also now correctly checks whether we're allowing URL params before checking them for the StreamerId.

Fixes #436

## Documentation

## Test Plan and Compatibility
