### PR TITLE
Update cirrus.js - More informative error messages - Fixes EpicGames/PixelStreamingInfrastructure#184

### DIFF
--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -659,7 +659,7 @@ streamerServer.on('connection', function (ws, req) {
 		console.error(`streamer ${streamer.id} connection error: ${error}`);
 		onStreamerDisconnected(streamer);
 		try {
-			ws.close(1006 /* abnormal closure */, error);
+			ws.close(1006 /* abnormal closure */, `streamer ${streamer.id} connection error: ${error}`);
 		} catch(err) {
 			console.error(`ERROR: ws.on error: ${err.message}`);
 		}
@@ -823,7 +823,7 @@ sfuServer.on('connection', function (ws, req) {
 		console.error(`SFU connection error: ${error}`);
 		onSFUDisconnected(playerComponent);
 		try {
-			ws.close(1006 /* abnormal closure */, error);
+			ws.close(1006 /* abnormal closure */, `SFU connection error: ${error}`);
 		} catch(err) {
 			console.error(`ERROR: ws.on error: ${err.message}`);
 		}
@@ -951,7 +951,7 @@ playerServer.on('connection', function (ws, req) {
 
 	ws.on('error', function(error) {
 		console.error(`player ${playerId} connection error: ${error}`);
-		ws.close(1006 /* abnormal closure */, error);
+		ws.close(1006 /* abnormal closure */, `player ${playerId} connection error: ${error}`);
 		onPlayerDisconnected(playerId);
 
 		console.logColor(logging.Red, `Trying to reconnect...`);


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Fixed an Issue regarding the WebSocket disconnect error messages. I made them more informative so they can assist with debugging. [Issue #184](https://github.com/EpicGames/PixelStreamingInfrastructure/issues/184)
"Currently, all websocket disconnects are presented with the same "Websocket disconnected: 1006" error (see screenshot). This is a generic error, but not overly useful to assist with debugging whether UE disconnected or the browser disconnected."

## Solution
On abnormal closure the cirrus.js called `ws.close(1006, error)`. I insterted more information/explanation about the error and then added the error at the end of the message. Example: `ws.close(1006, "SFU connection error: ${error}");`
It makes the default error message more informative as described in [Issue #184](https://github.com/EpicGames/PixelStreamingInfrastructure/issues/184)
Affected Lines:
[Line 662](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/SignallingWebServer/cirrus.js#L662)
[Line 826](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/SignallingWebServer/cirrus.js#L826)
[Line 954](https://github.com/EpicGames/PixelStreamingInfrastructure/blob/master/SignallingWebServer/cirrus.js#L954)

## Documentation

## Test Plan and Compatibility
