### PR TITLE
Small signalling server fixes.

### DIFF
--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -550,6 +550,10 @@ function registerStreamer(id, streamer) {
 }
 
 function onStreamerDisconnected(streamer) {
+	if (!!streamer.idTimer) {
+		clearTimeout(streamer.idTimer);
+	}
+
 	if (!streamer.id || !streamers.has(streamer.id)) {
 		return;
 	}
@@ -665,7 +669,10 @@ streamerServer.on('connection', function (ws, req) {
 		}
 	});
 
-	ws.send(JSON.stringify(clientConfig));
+	const configStr = JSON.stringify(clientConfig);
+	logOutgoing(streamer.id, configStr)
+	ws.send(configStr);
+
 	requestStreamerId(streamer);
 });
 
@@ -960,7 +967,11 @@ playerServer.on('connection', function (ws, req) {
 
 	sendPlayerConnectedToFrontend();
 	sendPlayerConnectedToMatchmaker();
-	player.ws.send(JSON.stringify(clientConfig));
+
+	const configStr = JSON.stringify(clientConfig);
+	logOutgoing(player.id, configStr)
+	player.ws.send(configStr);
+
 	sendPlayersCount();
 });
 

--- a/SignallingWebServer/modules/logging.js
+++ b/SignallingWebServer/modules/logging.js
@@ -7,18 +7,6 @@ var loggers=[];
 var logFunctions=[];
 var logColorFunctions=[];
 
-console.log = function(msg, ...args) {
-	logFunctions.forEach((logFunction) => {
-		logFunction(msg, ...args);
-	});
-}
-
-console.logColor = function(color, msg, ...args) {
-	logColorFunctions.forEach((logColorFunction) => {
-		logColorFunction(color, msg, ...args);
-	});
-}
-
 const AllAttributesOff = '\x1b[0m';
 const BoldOn = '\x1b[1m';
 const Black = '\x1b[30m';
@@ -30,6 +18,30 @@ const Magenta = '\x1b[35m';
 const Cyan = '\x1b[36m';
 const White = '\x1b[37m';
 const Orange = '\x1b[38;5;215m';
+
+console.log = function(msg, ...args) {
+	logFunctions.forEach((logFunction) => {
+		logFunction(msg, ...args);
+	});
+}
+
+console.warn = function(msg, ...args) {
+	logColorFunctions.forEach((logColorFunction) => {
+		logColorFunction(Yellow, msg, ...args);
+	});
+}
+
+console.error = function(msg, ...args) {
+	logColorFunctions.forEach((logColorFunction) => {
+		logColorFunction(Red, msg, ...args);
+	});
+}
+
+console.logColor = function(color, msg, ...args) {
+	logColorFunctions.forEach((logColorFunction) => {
+		logColorFunction(color, msg, ...args);
+	});
+}
 
 /**
  * Pad the start of the given number with zeros so it takes up the number of digits.


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Two issues:
- Some logging calls like console.warn and console.error were not captured by the logging system and thus were not logged to files.
- If a streamer disconnected before it identified itself the id timer was never cleared and so a bad legacy name would be added and left behind.

## Solution
- Added extra handlers for console.warn and console.error to properly log them.
- Cleared any id timer on streamer disconnect.

Fixes #439
