### PR TITLE
Update platform scripts so that the BASH_LOCATION works on Mac as well

### DIFF
--- a/Matchmaker/platform_scripts/bash/run.sh
+++ b/Matchmaker/platform_scripts/bash/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
-BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASH_LOCATION="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 pushd "${BASH_LOCATION}" > /dev/null
 

--- a/Matchmaker/platform_scripts/bash/setup.sh
+++ b/Matchmaker/platform_scripts/bash/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
-BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASH_LOCATION="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 pushd "${BASH_LOCATION}" > /dev/null
 

--- a/SFU/platform_scripts/bash/run_cloud.sh
+++ b/SFU/platform_scripts/bash/run_cloud.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
-BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASH_LOCATION="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 pushd "${BASH_LOCATION}" > /dev/null
 

--- a/SFU/platform_scripts/bash/run_local.sh
+++ b/SFU/platform_scripts/bash/run_local.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
-BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASH_LOCATION="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 pushd "${BASH_LOCATION}" > /dev/null
 

--- a/SFU/platform_scripts/bash/setup.sh
+++ b/SFU/platform_scripts/bash/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
-BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASH_LOCATION="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 pushd "${BASH_LOCATION}" > /dev/null
 

--- a/SignallingWebServer/platform_scripts/bash/Start_SignallingServer.sh
+++ b/SignallingWebServer/platform_scripts/bash/Start_SignallingServer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
-BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASH_LOCATION="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 pushd "${BASH_LOCATION}" > /dev/null
 

--- a/SignallingWebServer/platform_scripts/bash/Start_TURNServer.sh
+++ b/SignallingWebServer/platform_scripts/bash/Start_TURNServer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
-BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASH_LOCATION="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 pushd "${BASH_LOCATION}" > /dev/null
 

--- a/SignallingWebServer/platform_scripts/bash/Start_WithTURN_SignallingServer.sh
+++ b/SignallingWebServer/platform_scripts/bash/Start_WithTURN_SignallingServer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
-BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASH_LOCATION="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 pushd "${BASH_LOCATION}" > /dev/null
 

--- a/SignallingWebServer/platform_scripts/bash/docker-build-cirrus.sh
+++ b/SignallingWebServer/platform_scripts/bash/docker-build-cirrus.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
-BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASH_LOCATION="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 pushd "${BASH_LOCATION}" > /dev/null
 

--- a/SignallingWebServer/platform_scripts/bash/run_local.sh
+++ b/SignallingWebServer/platform_scripts/bash/run_local.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
-BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASH_LOCATION="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 
 pushd "${BASH_LOCATION}" > /dev/null
 

--- a/SignallingWebServer/platform_scripts/bash/setup.sh
+++ b/SignallingWebServer/platform_scripts/bash/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright Epic Games, Inc. All Rights Reserved.
-BASH_LOCATION=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASH_LOCATION="$(cd -P -- "$(dirname -- "$0")" && pwd -P)"
 NODE_VERSION=v18.17.0
 
 pushd "${BASH_LOCATION}" > /dev/null


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [X] Platform scripts
- [ ] SFU

## Problem statement:
The logic for detecting the script location is only suitable for bash. This PR makes the logic work on both bash and zsh.

## Test Plan and Compatibility
Tested script execution on Mac and Linux
