### PR TITLE
Fix warnings about GamepadButtonReleased

### DIFF
--- a/Frontend/library/src/Inputs/GamepadController.ts
+++ b/Frontend/library/src/Inputs/GamepadController.ts
@@ -202,7 +202,8 @@ export class GamePadController {
                     } else {
                         toStreamerHandlers.get('GamepadButtonReleased')([
                             controllerIndex,
-                            i
+                            i,
+                            0
                         ]);
                     }
                 }


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
`GamepadButtonReleased` is not successfully triggered as the data array doesn't match the expected values.

![image](https://github.com/EpicGames/PixelStreamingInfrastructure/assets/29305253/2bee3c0c-6d93-4bca-be4b-66b95e24d19b)


## Solution
The solution is to modify the data array sent with `GamepadButtonReleased` to be the expected size. In this case, that requires sending an additional int (which defaults to 0) to represent the `IsRepeat` data.

## Test Plan and Compatibility
Tested using a Xbox Series X/S Wireless Controller
