### PR TITLE
Ensure latencytest handles statpanel being disabled

### DIFF
--- a/Frontend/ui-library/src/Application/Application.ts
+++ b/Frontend/ui-library/src/Application/Application.ts
@@ -575,9 +575,11 @@ export class Application {
             );
         }
         // disable starting a latency check
-        this.statsPanel.latencyTest.latencyTestButton.onclick = () => {
-            // do nothing
-        };
+        if (!!this.statsPanel) {
+            this.statsPanel.latencyTest.latencyTestButton.onclick = () => {
+                // do nothing
+            };
+        }
     }
 
     /**
@@ -626,9 +628,11 @@ export class Application {
         }
 
         // starting a latency check
-        this.statsPanel.latencyTest.latencyTestButton.onclick = () => {
-            this.stream.requestLatencyTest();
-        };
+        if (!!this.statsPanel) {
+            this.statsPanel.latencyTest.latencyTestButton.onclick = () => {
+                this.stream.requestLatencyTest();
+            };
+        }
     }
 
     /**


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Frontend library
- [X] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Warnings are thrown when running a stream with the stats panel disabled because the latency test doesn't currently check if the stats panel is valid.

## Solution
Check if the stats panel is valid before attempting to access the latencyTest member.