### PR TITLE
Export NO_SUDO so it's available for use in launched processes

### DIFF
--- a/SignallingWebServer/platform_scripts/bash/common_utils.sh
+++ b/SignallingWebServer/platform_scripts/bash/common_utils.sh
@@ -79,6 +79,7 @@ function call_setup_sh() {
 }
 
 function start_process() {
+  export NO_SUDO=$NO_SUDO
 	if [ ! -z $NO_SUDO ]; then
 		log_msg "running with sudo removed"
 		eval $(echo "$@" | sed 's/sudo//g')


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [X] Platform scripts
- [ ] SFU

## Problem statement:
When launching the platform script on Mac, it always tries to launch the npm process with sudo, even if you pass `--nosudo` on the command line.

## Solution
By exporting the `NO_SUDO` variable, the npm process use it's value when determining whether to launch cirrus with `sudo` or not.
