### PR TITLE
Remove Unreal version from cirrus log

### DIFF
--- a/SignallingWebServer/cirrus.js
+++ b/SignallingWebServer/cirrus.js
@@ -246,7 +246,7 @@ if (config.UseHTTPS) {
 	});
 }
 
-console.logColor(logging.Cyan, `Running Cirrus - The Pixel Streaming reference implementation signalling server for Unreal Engine 5.3.`);
+console.logColor(logging.Cyan, `Running Cirrus - The Pixel Streaming reference implementation signalling server for Unreal Engine.`);
 
 let nextPlayerId = 1;
 


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
The master, 5.5 and 5.4 branches still log that Cirrus is for Unreal 5.3
`Running Cirrus - The Pixel Streaming reference implementation signalling server for Unreal Engine 5.3`

## Solution
As this version number isn't very important and it has proven easy to forget on updates, just remove it.
`Running Cirrus - The Pixel Streaming reference implementation signalling server for Unreal Engine`

## Documentation
N / A

## Test Plan and Compatibility
N / A
