### PR TITLE
Add TCP+Relay detection event

### DIFF
--- a/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
+++ b/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
@@ -171,7 +171,7 @@ export class AggregatedStats {
      */
     handleRemoteCandidate(stat: CandidateStat) {
         const RemoteCandidate = new CandidateStat();
-        RemoteCandidate.label = 'local-candidate';
+        RemoteCandidate.label = 'remote-candidate';
         RemoteCandidate.address = stat.address;
         RemoteCandidate.port = stat.port;
         RemoteCandidate.protocol = stat.protocol;

--- a/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
+++ b/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
@@ -120,9 +120,8 @@ export class AggregatedStats {
      * @param stat - the stats coming in from ice candidates
      */
     handleCandidatePair(stat: CandidatePairStats) {
-
-        // If the candidate pair is nominated and selected set to the candidate pair
-        if (stat.nominated && stat.selected){
+        // If the candidate pair has received bytes then set as the candidate pair
+        if (stat.bytesReceived > 0){
             this.candidatePair = stat;
         }
     }

--- a/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
+++ b/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
@@ -312,11 +312,6 @@ export class AggregatedStats {
      * @returns The candidate pair that is currently receiving data
      */
     public getActiveCandidatePair(): CandidatePairStats | null {
-        this.candidatePairs.forEach((candidatePair) => {
-            if (candidatePair.bytesReceived >0) {
-                return candidatePair
-            }
-        })
-        return null
+        return this.candidatePairs.find((candidatePair) => candidatePair.bytesReceived > 0, null)
     }  
 }

--- a/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
+++ b/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
@@ -120,16 +120,11 @@ export class AggregatedStats {
      * @param stat - the stats coming in from ice candidates
      */
     handleCandidatePair(stat: CandidatePairStats) {
-        this.candidatePair.bytesReceived = stat.bytesReceived;
-        this.candidatePair.bytesSent = stat.bytesSent;
-        this.candidatePair.localCandidateId = stat.localCandidateId;
-        this.candidatePair.remoteCandidateId = stat.remoteCandidateId;
-        this.candidatePair.nominated = stat.nominated;
-        this.candidatePair.readable = stat.readable;
-        this.candidatePair.selected = stat.selected;
-        this.candidatePair.writable = stat.writable;
-        this.candidatePair.state = stat.state;
-        this.candidatePair.currentRoundTripTime = stat.currentRoundTripTime;
+
+        // If the candidate pair is nominated and selected set to the candidate pair
+        if (stat.nominated && stat.selected){
+            this.candidatePair = stat;
+        }
     }
 
     /**

--- a/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
+++ b/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
@@ -25,7 +25,7 @@ export class AggregatedStats {
     inboundAudioStats: InboundAudioStats;
     lastVideoStats: InboundVideoStats;
     lastAudioStats: InboundAudioStats;
-    candidatePair: CandidatePairStats;
+    candidatePairs: Array<CandidatePairStats>;
     DataChannelStats: DataChannelStats;
     localCandidates: Array<CandidateStat>;
     remoteCandidates: Array<CandidateStat>;
@@ -37,7 +37,6 @@ export class AggregatedStats {
     constructor() {
         this.inboundVideoStats = new InboundVideoStats();
         this.inboundAudioStats = new InboundAudioStats();
-        this.candidatePair = new CandidatePairStats();
         this.DataChannelStats = new DataChannelStats();
         this.outBoundVideoStats = new OutBoundVideoStats();
         this.sessionStats = new SessionStats();
@@ -52,6 +51,7 @@ export class AggregatedStats {
     processStats(rtcStatsReport: RTCStatsReport) {
         this.localCandidates = new Array<CandidateStat>();
         this.remoteCandidates = new Array<CandidateStat>();
+        this.candidatePairs = new Array<CandidatePairStats>();
 
         rtcStatsReport.forEach((stat) => {
             const type: RTCStatsTypePS = stat.type;
@@ -120,10 +120,10 @@ export class AggregatedStats {
      * @param stat - the stats coming in from ice candidates
      */
     handleCandidatePair(stat: CandidatePairStats) {
-        // If the candidate pair has received bytes then set as the candidate pair
-        if (stat.bytesReceived > 0){
-            this.candidatePair = stat;
-        }
+
+        // Add the candidate pair to the candidate pair array
+        this.candidatePairs.push(stat)
+
     }
 
     /**
@@ -306,4 +306,17 @@ export class AggregatedStats {
     isNumber(value: unknown): boolean {
         return typeof value === 'number' && isFinite(value);
     }
+
+    /**
+     * Helper function to return the active candidate pair
+     * @returns The candidate pair that is currently receiving data
+     */
+    public getActiveCandidatePair(): CandidatePairStats | null {
+        this.candidatePairs.forEach((candidatePair) => {
+            if (candidatePair.bytesReceived >0) {
+                return candidatePair
+            }
+        })
+        return null
+    }  
 }

--- a/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
+++ b/Frontend/library/src/PeerConnectionController/AggregatedStats.ts
@@ -162,6 +162,8 @@ export class AggregatedStats {
         localCandidate.protocol = stat.protocol;
         localCandidate.candidateType = stat.candidateType;
         localCandidate.id = stat.id;
+        localCandidate.relayProtocol = stat.relayProtocol;
+        localCandidate.transportId = stat.transportId;
         this.localCandidates.push(localCandidate);
     }
 
@@ -177,6 +179,8 @@ export class AggregatedStats {
         RemoteCandidate.protocol = stat.protocol;
         RemoteCandidate.id = stat.id;
         RemoteCandidate.candidateType = stat.candidateType;
+        RemoteCandidate.relayProtocol = stat.relayProtocol;
+        RemoteCandidate.transportId = stat.transportId
         this.remoteCandidates.push(RemoteCandidate);
     }
 

--- a/Frontend/library/src/PeerConnectionController/CandidatePairStats.ts
+++ b/Frontend/library/src/PeerConnectionController/CandidatePairStats.ts
@@ -6,12 +6,19 @@
 export class CandidatePairStats {
     bytesReceived: number;
     bytesSent: number;
+    currentRoundTripTime: number;
+    id: string;
+    lastPacketReceivedTimestamp: number;
+    lastPacketSentTimestamp: number;
     localCandidateId: string;
-    remoteCandidateId: string;
     nominated: boolean;
+    priority: number;
     readable: boolean;
-    writable: boolean;
+    remoteCandidateId: string;
     selected: boolean;
     state: string;
-    currentRoundTripTime: number;
+    timestamp: number;
+    transportId: string;
+    type: string;
+    writable: boolean;  
 }

--- a/Frontend/library/src/PeerConnectionController/CandidateStat.ts
+++ b/Frontend/library/src/PeerConnectionController/CandidateStat.ts
@@ -4,10 +4,12 @@
  * ICE Candidate Stat collected from the RTC Stats Report
  */
 export class CandidateStat {
-    label: string;
-    id: string;
     address: string;
     candidateType: string;
+    id: string;
+    label: string;    
     port: number;
     protocol: 'tcp' | 'udp';
+    relayProtocol: 'tcp' | 'udp' | 'tls';
+    transportId: string;
 }

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.test.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.test.ts
@@ -398,9 +398,9 @@ describe('PixelStreaming', () => {
             expect.objectContaining({
                 data: {
                     aggregatedStats: expect.objectContaining({
-                        candidatePair: expect.objectContaining({
-                            bytesReceived: 123
-                        }),
+                        candidatePairs: [
+                            expect.objectContaining({ bytesReceived: 123 })
+                        ],
                         localCandidates: [
                             expect.objectContaining({ address: 'mock-address' })
                         ]

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -119,17 +119,18 @@ export class PixelStreaming {
 
         this._webXrController = new WebXRController(this._webRtcController);
 
-        this._setupWebRtcTCPRelayDetection = this._setupWebRtcTCPRelayDetection.bind(this)
-
         // Add event listener for the webRtcConnected event
         this._eventEmitter.addEventListener("webRtcConnected", (webRtcConnectedEvent: WebRtcConnectedEvent) => {
 
             // Bind to the stats received event
-            this._eventEmitter.addEventListener("statsReceived", this._setupWebRtcTCPRelayDetection);
-
+            this._eventEmitter.addEventListener("statsReceived",  (statsReceivedEvent: StatsReceivedEvent) => { this._setupWebRtcTCPRelayDetection(statsReceivedEvent)});
         });
     }
 
+
+    
+
+    
     /**
      * Gets the element that contains the video stream element.
      */
@@ -657,7 +658,7 @@ export class PixelStreaming {
                 this._eventEmitter.dispatchEvent(new WebRtcTCPRelayDetectedEvent());
             }
             // The check is completed and the stats listen event can be removed
-            this._eventEmitter.removeEventListener("statsReceived", this._setupWebRtcTCPRelayDetection);
+            this._eventEmitter.removeEventListener("statsReceived",  (statsReceivedEvent: StatsReceivedEvent) => { this._setupWebRtcTCPRelayDetection(statsReceivedEvent)});
         }
     }
 

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -63,6 +63,7 @@ export class PixelStreaming {
     protected _webRtcController: WebRtcPlayerController;
     protected _webXrController: WebXRController;
     protected _dataChannelLatencyTestController: DataChannelLatencyTestController;
+
     /**
      * Configuration object. You can read or modify config through this object. Whenever
      * the configuration is changed, the library will emit a `settingsChanged` event.
@@ -118,38 +119,16 @@ export class PixelStreaming {
 
         this._webXrController = new WebXRController(this._webRtcController);
 
+        this._setupWebRtcTCPRelayDetection = this._setupWebRtcTCPRelayDetection.bind(this)
+
         // Add event listener for the webRtcConnected event
         this._eventEmitter.addEventListener("webRtcConnected", (webRtcConnectedEvent: WebRtcConnectedEvent) => {
-            
-            // Create a function to handle the web rtc tcp detect check the stats received event
-            let webRTCTCPdetectCheck = (statsReceivedEvent: StatsReceivedEvent) => {
-      
-                // Get the active candidate pair
-                let activeCandidatePair = statsReceivedEvent.data.aggregatedStats.getActiveCandidatePair();
-        
-                // Check if the active candidate pair is not null
-                if (activeCandidatePair != null) {
-        
-                    // Get the local candidate assigned to the active candidate pair
-                    let localCandidate = statsReceivedEvent.data.aggregatedStats.localCandidates.find((candidate) => candidate.id == activeCandidatePair.localCandidateId, null)
-        
-                    // Check if the local candidate is not null, candidate type is relay and the relay protocol is tcp
-                    if (localCandidate != null && localCandidate.candidateType == 'relay' && localCandidate.relayProtocol == 'tcp') {
-        
-                        // Send the web rtc tcp relay detected Evebt
-                        this._eventEmitter.dispatchEvent(new WebRtcTCPRelayDetectedEvent());
-                    }
-                    // The check is completed and the stats listen event can be removed
-                    this._eventEmitter.removeEventListener("statsReceived", webRTCTCPdetectCheck);
-                }
-            }
 
             // Bind to the stats received event
-            this._eventEmitter.addEventListener("statsReceived", webRTCTCPdetectCheck);
+            this._eventEmitter.addEventListener("statsReceived", this._setupWebRtcTCPRelayDetection);
+
         });
     }
-
-
 
     /**
      * Gets the element that contains the video stream element.
@@ -658,6 +637,28 @@ export class PixelStreaming {
         this._eventEmitter.dispatchEvent(
             new PlayerCountEvent({ count: playerCount })
         );
+    }
+
+    // Sets up to emit the webrtc tcp relay detect event 
+    _setupWebRtcTCPRelayDetection(statsReceivedEvent: StatsReceivedEvent) {
+        // Get the active candidate pair
+        let activeCandidatePair = statsReceivedEvent.data.aggregatedStats.getActiveCandidatePair();
+                
+        // Check if the active candidate pair is not null
+        if (activeCandidatePair != null) {
+
+            // Get the local candidate assigned to the active candidate pair
+            let localCandidate = statsReceivedEvent.data.aggregatedStats.localCandidates.find((candidate) => candidate.id == activeCandidatePair.localCandidateId, null)
+
+            // Check if the local candidate is not null, candidate type is relay and the relay protocol is tcp
+            if (localCandidate != null && localCandidate.candidateType == 'relay' && localCandidate.relayProtocol == 'tcp') {
+
+                // Send the web rtc tcp relay detected event
+                this._eventEmitter.dispatchEvent(new WebRtcTCPRelayDetectedEvent());
+            }
+            // The check is completed and the stats listen event can be removed
+            this._eventEmitter.removeEventListener("statsReceived", this._setupWebRtcTCPRelayDetection);
+        }
     }
 
     /**

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -123,7 +123,7 @@ export class PixelStreaming {
         this._eventEmitter.addEventListener("webRtcConnected", (webRtcConnectedEvent: WebRtcConnectedEvent) => {
 
             // Bind to the stats received event
-            this._eventEmitter.addEventListener("statsReceived",  (statsReceivedEvent: StatsReceivedEvent) => { this._setupWebRtcTCPRelayDetection(statsReceivedEvent)});
+            this._eventEmitter.addEventListener("statsReceived",  this._setupWebRtcTCPRelayDetection.bind(this));
         });
     }
 
@@ -654,7 +654,7 @@ export class PixelStreaming {
                 this._eventEmitter.dispatchEvent(new WebRtcTCPRelayDetectedEvent());
             }
             // The check is completed and the stats listen event can be removed
-            this._eventEmitter.removeEventListener("statsReceived",  (statsReceivedEvent: StatsReceivedEvent) => { this._setupWebRtcTCPRelayDetection(statsReceivedEvent)});
+            this._eventEmitter.removeEventListener("statsReceived", this._setupWebRtcTCPRelayDetection);
         }
     }
 

--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -127,10 +127,6 @@ export class PixelStreaming {
         });
     }
 
-
-    
-
-    
     /**
      * Gets the element that contains the video stream element.
      */

--- a/Frontend/library/src/Util/EventEmitter.ts
+++ b/Frontend/library/src/Util/EventEmitter.ts
@@ -538,19 +538,12 @@ export class PlayerCountEvent extends Event {
 }
 
 /**
- * An event that is emitted when the stream quality is degraded due to local network environment.
+ * An event that is emitted when the webRTC connections is relayed over TCP.
  */
-export class StreamWarningEvent extends Event {
-    readonly type: 'streamWarning';
-    readonly data: {
-        /** stream warning event */
-        protocol: 'tcp' | 'udp'
-        relayProtocol: 'tcp' | 'udp' | 'tls'
-        candidateType: string
-    };
-    constructor(data: StreamWarningEvent['data']) {
-        super('streamWarning');
-        this.data = data;
+export class WebRtcTCPRelayDetectedEvent extends Event {
+    readonly type: 'webRtcTCPRelayDetected';
+    constructor() {
+        super('webRtcTCPRelayDetected');
     }
 }
 
@@ -574,7 +567,6 @@ export type PixelStreamingEvent =
     | StreamPreConnectEvent
     | StreamReconnectEvent
     | StreamPreDisconnectEvent
-    | StreamWarningEvent    
     | PlayStreamErrorEvent
     | PlayStreamEvent
     | PlayStreamRejectedEvent
@@ -591,7 +583,8 @@ export type PixelStreamingEvent =
     | XrSessionStartedEvent
     | XrSessionEndedEvent
     | XrFrameEvent
-    | PlayerCountEvent;
+    | PlayerCountEvent
+    | WebRtcTCPRelayDetectedEvent;
 
 export class EventEmitter extends EventTarget {
     /**

--- a/Frontend/library/src/Util/EventEmitter.ts
+++ b/Frontend/library/src/Util/EventEmitter.ts
@@ -537,6 +537,23 @@ export class PlayerCountEvent extends Event {
     }
 }
 
+/**
+ * An event that is emitted when the stream quality is degraded due to local network environment.
+ */
+export class StreamWarningEvent extends Event {
+    readonly type: 'streamWarning';
+    readonly data: {
+        /** stream warning event */
+        protocol: 'tcp' | 'udp'
+        relayProtocol: 'tcp' | 'udp' | 'tls'
+        candidateType: string
+    };
+    constructor(data: StreamWarningEvent['data']) {
+        super('streamWarning');
+        this.data = data;
+    }
+}
+
 export type PixelStreamingEvent =
     | AfkWarningActivateEvent
     | AfkWarningUpdateEvent
@@ -557,6 +574,7 @@ export type PixelStreamingEvent =
     | StreamPreConnectEvent
     | StreamReconnectEvent
     | StreamPreDisconnectEvent
+    | StreamWarningEvent    
     | PlayStreamErrorEvent
     | PlayStreamEvent
     | PlayStreamRejectedEvent

--- a/Frontend/ui-library/src/Application/Application.ts
+++ b/Frontend/ui-library/src/Application/Application.ts
@@ -378,6 +378,14 @@ export class Application {
             ({ data: { count }}) => 
                 this.onPlayerCount(count)
         );
+        this.stream.addEventListener(
+            'webRtcTCPRelayDetected', 
+            ({}) => 
+                Logger.Warning(
+                    Logger.GetStackTrace(),
+                    `Stream quailty degraded due to network enviroment, stream is relayed over TCP.`
+               )
+        );
     }
 
     /**

--- a/Frontend/ui-library/src/UI/StatsPanel.ts
+++ b/Frontend/ui-library/src/UI/StatsPanel.ts
@@ -318,14 +318,17 @@ export class StatsPanel {
             );
         }
 
+        // Store the active candidate pair
+        let activeCandidatePair = stats.getActiveCandidatePair();
+
         // RTT
         const netRTT =
             Object.prototype.hasOwnProperty.call(
-                stats.getActiveCandidatePair(),
+                activeCandidatePair,
                 'currentRoundTripTime'
-            ) && stats.isNumber(stats.getActiveCandidatePair().currentRoundTripTime)
+            ) && stats.isNumber(activeCandidatePair.currentRoundTripTime)
                 ? numberFormat.format(
-                      stats.getActiveCandidatePair().currentRoundTripTime * 1000
+                    activeCandidatePair.currentRoundTripTime * 1000
                   )
                 : "Can't calculate";
         this.addOrUpdateStat('RTTStat', 'Net RTT (ms)', netRTT);

--- a/Frontend/ui-library/src/UI/StatsPanel.ts
+++ b/Frontend/ui-library/src/UI/StatsPanel.ts
@@ -321,11 +321,11 @@ export class StatsPanel {
         // RTT
         const netRTT =
             Object.prototype.hasOwnProperty.call(
-                stats.candidatePair,
+                stats.getActiveCandidatePair(),
                 'currentRoundTripTime'
-            ) && stats.isNumber(stats.candidatePair.currentRoundTripTime)
+            ) && stats.isNumber(stats.getActiveCandidatePair().currentRoundTripTime)
                 ? numberFormat.format(
-                      stats.candidatePair.currentRoundTripTime * 1000
+                      stats.getActiveCandidatePair().currentRoundTripTime * 1000
                   )
                 : "Can't calculate";
         this.addOrUpdateStat('RTTStat', 'Net RTT (ms)', netRTT);

--- a/Frontend/ui-library/src/UI/StatsPanel.ts
+++ b/Frontend/ui-library/src/UI/StatsPanel.ts
@@ -1,7 +1,7 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
 import { LatencyTest } from './LatencyTest';
-import { InitialSettings, Logger, PixelStreaming } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.4';
+import { CandidatePairStats, InitialSettings, Logger, PixelStreaming } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.4';
 import { AggregatedStats } from '@epicgames-ps/lib-pixelstreamingfrontend-ue5.4';
 import { MathUtils } from '../Util/MathUtils';
 import {DataChannelLatencyTest} from "./DataChannelLatencyTest";
@@ -318,8 +318,8 @@ export class StatsPanel {
             );
         }
 
-        // Store the active candidate pair
-        let activeCandidatePair = stats.getActiveCandidatePair();
+        // Store the active candidate pair return a new Candidate pair stat if getActiveCandidate is null
+        let activeCandidatePair = stats.getActiveCandidatePair() != null ? stats.getActiveCandidatePair() : new CandidatePairStats();
 
         // RTT
         const netRTT =


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [x] Frontend library
- [x] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
There is currently no event emitted if the local candidate is relayed over TCP
this can happen if the local candidate is connected to a TURN server and the transport is TCP
This will degrade the stream quality severely

## Solution
- Log to the console a `Stream quality severely degraded, local connection is relayed over TCP due to the local network environment.` message
- Once the stream has started if the local candidate type is relay and the relay protocol is TCP then emit a stream warning event for a user to consume to set their own message

## Documentation

To subscribe to the event
```ts
	stream.addEventListener('webRtcTCPRelayDetected', (event: WebRtcTCPReldayDectectedEvent) => {
		console.log("TCP + TURN detected: " + JSON.stringify(event.data))
	});
	
```
