### PR TITLE
Fix touch events not working on iOS

### DIFF
--- a/Frontend/library/src/Inputs/TouchController.ts
+++ b/Frontend/library/src/Inputs/TouchController.ts
@@ -178,7 +178,7 @@ export class TouchController implements ITouchController {
                         coord.x,
                         coord.y,
                         this.fingerIds.get(touch.identifier),
-                        this.maxByteValue * touch.force,
+                        this.maxByteValue * (touch.force > 0 ? touch.force : 1),
                         coord.inRange ? 1 : 0
                     ]);
                     break;
@@ -198,7 +198,7 @@ export class TouchController implements ITouchController {
                         coord.x,
                         coord.y,
                         this.fingerIds.get(touch.identifier),
-                        this.maxByteValue * touch.force,
+                        this.maxByteValue * (touch.force > 0 ? touch.force : 1),
                         coord.inRange ? 1 : 0
                     ]);
                     break;


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
This PR addresses the problems identified in https://github.com/EpicGames/PixelStreamingInfrastructure/issues/376

## Solution
With the removal of 3D Touch from iPhones since the iPhone XS, the `force` property on the `Touch` event always reports 0. This PR adds a simple check to see if the `force` is 0 for either a touch start or move, and if so it forces it to 1. This is not required on touch ends as a touch can't end with a non-zero force.
