### PR TITLE
Bug Fix TCP Relay event to only be emitted once

### DIFF
--- a/Frontend/library/src/PixelStreaming/PixelStreaming.ts
+++ b/Frontend/library/src/PixelStreaming/PixelStreaming.ts
@@ -119,11 +119,13 @@ export class PixelStreaming {
 
         this._webXrController = new WebXRController(this._webRtcController);
 
+        this._setupWebRtcTCPRelayDetection = this._setupWebRtcTCPRelayDetection.bind(this)
+
         // Add event listener for the webRtcConnected event
         this._eventEmitter.addEventListener("webRtcConnected", (webRtcConnectedEvent: WebRtcConnectedEvent) => {
 
             // Bind to the stats received event
-            this._eventEmitter.addEventListener("statsReceived",  this._setupWebRtcTCPRelayDetection.bind(this));
+            this._eventEmitter.addEventListener("statsReceived",  this._setupWebRtcTCPRelayDetection);
         });
     }
 


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
The `WebRtcConnectedEvent` was not getting removed once the check had completed successfully. Due to the `_setupWebRtcTCPRelayDetect` losing context to `this`

## Solution
Bind the  `_setupWebRtcTCPRelayDetect` function to `this`.

## Documentation

## Test Plan and Compatibility
Ensured the event is only raised once if the WebRTC connection was made with TURN and the transport set to TCP
